### PR TITLE
Fix getting of Granularity parameter name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,4 @@ buildNumber.properties
 
 # IntelliJ IDEA Configs
 .idea
-partnersdk.iml
+partnercenter.iml

--- a/src/main/java/com/microsoft/store/partnercenter/utilization/AzureUtilizationCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/utilization/AzureUtilizationCollectionOperations.java
@@ -108,7 +108,7 @@ public class AzureUtilizationCollectionOperations
 		    (
 		    	new KeyValuePair<String, String>
 		        (
-		        	PartnerService.getInstance().getConfiguration().getApis().get( "GetAzureUtilizationRecords" ).getParameters().get( "Granularity "),
+		        	PartnerService.getInstance().getConfiguration().getApis().get( "GetAzureUtilizationRecords" ).getParameters().get( "Granularity" ),
 		        	granularity.toString()
 		        )
 		    );


### PR DESCRIPTION
# Description

The method returns null:

```java
PartnerService.getInstance().getConfiguration().getApis().get( "GetAzureUtilizationRecords" ).getParameters().get( "Granularity ") 
```

The typo in key:
`"Granularity "`
should be 
`"Granularity"`
without space at the end.