### PR TITLE
Override toString in enums

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/models/ContractType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/ContractType.java
@@ -6,25 +6,41 @@
 
 package com.microsoft.store.partnercenter.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ContractType
 {
     /**
      * Describes the type of contract Refers to a contract which provides subscription for the order item placed
      */
-    @JsonProperty( "subscription" ) 
-    SUBSCRIPTION,
+    SUBSCRIPTION("subscription"),
     
     /**
      * Refers to a contract which provides a product key result for the order item placed
      */
-    @JsonProperty( "productkey" ) 
-    PRODUCTKEY,
+    PRODUCTKEY("productkey"),
     
     /**
      * Refers to a contract which provides Redemption code result for the order item placed.
      */
-    @JsonProperty( "redemptioncode" ) 
-    REDEMPTIONCODE
+    REDEMPTIONCODE("redemptioncode");
+
+    private final String value;
+
+    ContractType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementType.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.agreements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Enumeration to represent type of Agreements
@@ -16,6 +16,24 @@ public enum AgreementType
     /**
      * Microsoft cloud agreement type.
      */
-    @JsonProperty("MicrosoftCloudAgreement")
-    MICROSOFT_CLOUD_AGREEMENT
+    MICROSOFT_CLOUD_AGREEMENT("MicrosoftCloudAgreement");
+
+    private final String value;
+
+    AgreementType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/AuditRecordSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/AuditRecordSearchField.java
@@ -6,27 +6,44 @@
 
 package com.microsoft.store.partnercenter.models.auditing;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the supported audit search fields.
  */
-public enum AuditRecordSearchField {
+public enum AuditRecordSearchField
+{
     /**
      * Customer company name.
      */
-    @JsonProperty("CompanyName")
-    COMPANY_NAME,
+    COMPANY_NAME("CompanyName"),
 
     /**
      * Customer identifier (GUID).
      */
-    @JsonProperty("CustomerId")
-    CUSTOMER_ID,
+    CUSTOMER_ID("CustomerId"),
 
     /**
      * Resource Type as defined in available Resource Types (Example: Order, Subscription).
      */
-    @JsonProperty("ResourceType")
-    RESOURCE_TYPE
+    RESOURCE_TYPE("ResourceType");
+
+    private final String value;
+
+    AuditRecordSearchField(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationStatus.java
@@ -6,33 +6,49 @@
 
 package com.microsoft.store.partnercenter.models.auditing;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents status of an operation
  */
-public enum OperationStatus {
+public enum OperationStatus
+{
     /**
      * Indicates success of the operation
      */
-    @JsonProperty("succeeded")
-    SUCCEEDED,
+    SUCCEEDED("succeeded"),
 
     /**
      * Indicates failure of the operation
      */
-    @JsonProperty("failed")
-    FAILED,
+    FAILED("failed"),
 
     /**
      * Indicates that the operation is still in progress
      */
-    @JsonProperty("progress")
-    PROGRESS,
+    PROGRESS("progress"),
 
     /**
      * Indicates that the operation is declined
      */
-    @JsonProperty("decline")
-    DECLINE
+    DECLINE("decline");
+
+    private final String value;
+
+    OperationStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationType.java
@@ -6,9 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.auditing;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-// @JsonProperty("update_customer_qualification")
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Enumeration to represent type of operation being performed.
@@ -18,192 +16,179 @@ public enum OperationType
     /**
      * The undefined
      */
-    @JsonProperty("undefined")
-    UNDEFINED,
+    UNDEFINED("undefined"),
 
     /**
      * Update Customer Qualification
      */
-    @JsonProperty("update_customer_qualification")
-    UPDATE_CUSTOMER_QUALIFICATION,
-    
+    UPDATE_CUSTOMER_QUALIFICATION("update_customer_qualification"),
+
     /**
      * Updates an existing subscription.
      */
-    @JsonProperty("update_subscription")
-    UPDATE_SUBSCRIPTION,
+    UPDATE_SUBSCRIPTION("update_subscription"),
 
     /**
      * Transition a subscription.
      */
-    @JsonProperty("upgrade_subscription")
-    UPGRADE_SUBSCRIPTION,
-   
+    UPGRADE_SUBSCRIPTION("upgrade_subscription"),
+
     /**
      * Convert a trial subscription to a paid one.
      */
-    @JsonProperty("convert_trial_subscription")
-    CONVERT_TRIAL_SUBSCRIPTION,
+    CONVERT_TRIAL_SUBSCRIPTION("convert_trial_subscription"),
 
     /**
      * Adding a Customer
      */
-    @JsonProperty("add_customer")
-    ADD_CUSTOMER,
- 
+    ADD_CUSTOMER("add_customer"),
+
     /**
      * Update a Customer Billing Profile
      */
-    @JsonProperty("update_customer_billing_profile")
-    UPDATE_CUSTOMER_BILLING_PROFILE,
+    UPDATE_CUSTOMER_BILLING_PROFILE("update_customer_billing_profile"),
 
     /**
      * Update a Customer's Partner Contract Company Name
      */
-    @JsonProperty("update_customer_partner_contract_company_Name")
-    UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME,
+    UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME("update_customer_partner_contract_company_Name"),
 
     /**
      * Updates a customer spending budget.
      */
-    @JsonProperty("update_Customer_spending_budget")
-    UPDATECUSTOMERSPENDINGBUDGET, 
+    UPDATECUSTOMERSPENDINGBUDGET("update_Customer_spending_budget"),
 
     /**
      * Deleting a customer. This only happens in the sandbox integration accounts.
      */
-    @JsonProperty("delete_customer")
-    DELETE_CUSTOMER,
-    
+    DELETE_CUSTOMER("delete_customer"),
+
     /**
      * Remove Partner Customer relationship.
      */
-    @JsonProperty("remove_partner_customer_relationship")
-    REMOVE_PARTNER_CUSTOMER_RELATIONSHIP,
+    REMOVE_PARTNER_CUSTOMER_RELATIONSHIP("remove_partner_customer_relationship"),
 
     /**
      * Create a new order.
      */
-    @JsonProperty("create_order")
-    CREATE_ORDER,
-    
+    CREATE_ORDER("create_order"),
+
     /**
      * Updates an existing order.
      */
-    @JsonProperty("update_order")
-    UPDATE_ORDER,
-    
+    UPDATE_ORDER("update_order"),
+
     /**
      * Creates a customer user.
      */
-    @JsonProperty("create_customer_user")
-    CREATE_CUSTOMER_USER,
-    
+    CREATE_CUSTOMER_USER("create_customer_user"),
+
     /**
      * Deletes a customer user.
      */
-    @JsonProperty("delete_customer_user")
-    DELETE_CUSTOMER_USER,
-    
+    DELETE_CUSTOMER_USER("delete_customer_user"),
+
     /**
      * Updates a customer user.
      */
-    @JsonProperty("update_customer_user")
-    UPDATE_CUSTOMER_USER,
-    
+    UPDATE_CUSTOMER_USER("update_customer_user"),
+
     /**
      * Updates a customer user licenses.
      */
-    @JsonProperty("Update_customer_user_licenses")
-    UPDATE_CUSTOMER_USER_LICENSES,
-    
+    UPDATE_CUSTOMER_USER_LICENSES("Update_customer_user_licenses"),
+
     /**
      * Reset customer user password.
      */
-    @JsonProperty("reset_customer_user_password")
-    RESET_CUSTOMER_USER_PASSWORD,
-    
+    RESET_CUSTOMER_USER_PASSWORD("reset_customer_user_password"),
+
     /**
      * Update customer user UPN.
      */
-    @JsonProperty("update_customer_user_principal_name")
-    UPDATE_CUSTOMER_USER_PRINCIPAL_NAME,
-    
+    UPDATE_CUSTOMER_USER_PRINCIPAL_NAME("update_customer_user_principal_name"),
+
     /**
      * Restore customer user.
      */
-    @JsonProperty("restore_customer_user")
-    RESTORE_CUSTOMER_USER,
-    
+    RESTORE_CUSTOMER_USER("restore_customer_user"),
+
     /**
      * Create MPN association.
      */
-    @JsonProperty("create_mpn_association")
-    CREATE_MPN_ASSOCIATION,
-    
+    CREATE_MPN_ASSOCIATION("create_mpn_association"),
+
     /**
      * Update MPN association.
      */
-    @JsonProperty("update_mpn_association")
-    UPDATE_MPN_ASSOCIATION,
-    
+    UPDATE_MPN_ASSOCIATION("update_mpn_association"),
+
     /**
      * Updates a Sfb customer user licenses.
      */
-    @JsonProperty("update_sfb_customer_user_licenses")
-    UPDATE_SFB_CUSTOMER_USER_LICENSES,
-    
+    UPDATE_SFB_CUSTOMER_USER_LICENSES("update_sfb_customer_user_licenses"),
+
     /**
      * Update transfer.
      */
-    @JsonProperty("update_transfer")
-    UPDATE_TRANSFER,
-    
+    UPDATE_TRANSFER("update_transfer"),
+
     /**
      * Creates a partner relationship.
      */
-    @JsonProperty("create_partner_relationship")
-    CREATE_PARTNER_RELATIONSHIP,
-    
+    CREATE_PARTNER_RELATIONSHIP("create_partner_relationship"),
+
     /**
      * Add and registers an application.
      */
-    @JsonProperty("register_application")
-    REGISTER_APPLICATION,
-    
+    REGISTER_APPLICATION("register_application"),
+
     /**
      * Unregisters an application.
      */
-    @JsonProperty("unregister_application")
-    UNREGISTER_APPLICATION,
-    
+    UNREGISTER_APPLICATION("unregister_application"),
+
     /**
      * An application credential was added.
      */
-    @JsonProperty("add_application_credential")
-    ADD_APPLICATION_CREDENTIAL,
-    
+    ADD_APPLICATION_CREDENTIAL("add_application_credential"),
+
     /**
      * An application credential was removed.
      */
-    @JsonProperty("remove_application_credential")
-    REMOVE_APPLICATION_CREDENTIAL,
-    
+    REMOVE_APPLICATION_CREDENTIAL("remove_application_credential"),
+
     /**
      * Creates a partner user.
      */
-    @JsonProperty("create_partner_user")
-    CREATE_PARTNER_USER,    
-    
+    CREATE_PARTNER_USER("create_partner_user"),
+
     /**
      * Updates a partner user.
      */
-    @JsonProperty("update_partner_user")
-    UPDATE_PARTNER_USER,
-    
+    UPDATE_PARTNER_USER("update_partner_user"),
+
     /**
      * Removes a partner user.
      */
-    @JsonProperty("Remove_partner_user")
-    remove_partner_user,
+    remove_partner_user("Remove_partner_user");
+
+    private final String value;
+
+    OperationType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/ResourceType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/ResourceType.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.auditing;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Enumeration to represent type of resource being performed.
@@ -16,78 +16,84 @@ public enum ResourceType
     /**
      * The undefined
      */
-    @JsonProperty("undefined")
-    UNDEFINED, 
+    UNDEFINED("undefined"),
 
     /**
      * Customer Resource
      */
-    @JsonProperty("customer")
-    CUSTOMER,
+    CUSTOMER("customer"),
 
     /**
      * Customer User
      */
-    @JsonProperty("customer_user")
-    CUSTOMER_USER,
+    CUSTOMER_USER("customer_user"),
 
     /**
      * Order Resource
      */
-    @JsonProperty("order")
-    ORDER,
+    ORDER("order"),
 
     /**
      * Subscription Resource
      */
-    @JsonProperty("subscription")
-    SUBSCRIPTION,
+    SUBSCRIPTION("subscription"),
 
     /**
      * License Resource
      */
-    @JsonProperty("license")
-    LICENSE,
+    LICENSE("license"),
 
     /**
      * Third party add on Resource
      */
-    @JsonProperty("third_party_add_on")
-    THIRD_PARTY_ADD_ON,
+    THIRD_PARTY_ADD_ON("third_party_add_on"),
 
     /**
      * MPN association Resource
      */
-    @JsonProperty("mpn_association")
-    MPN_ASSOCIATION,
+    MPN_ASSOCIATION("mpn_association"),
 
     /**
      * Transfer Resource
      */
-    @JsonProperty("transfer")
-    TRANSFER, 
+    TRANSFER("transfer"),
 
     /**
      * Application Resource
      */
-    @JsonProperty("application")
-    APPLICATION,
- 
+    APPLICATION("application"),
+
     /**
      * Application Credential Resource
      */
-    @JsonProperty("application_credential")
-    APPLICATION_CREDENTIAL,
+    APPLICATION_CREDENTIAL("application_credential"),
 
     /**
      * Partner User Resource
      */
-    @JsonProperty("partner_user")
-    PARTNER_USER,
+    PARTNER_USER("partner_user"),
 
     /**
      * Partner Relationship Resource
      */
-    @JsonProperty("partner_relationship")
-    PARTNER_RELATIONSHIP
+    PARTNER_RELATIONSHIP("partner_relationship");
+
+    private final String value;
+
+    ResourceType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/carts/ParticipantType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/carts/ParticipantType.java
@@ -6,21 +6,39 @@
 
 package com.microsoft.store.partnercenter.models.carts;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Types of Participants
  */
-public enum ParticipantType {
+public enum ParticipantType
+{
     /**
      * Default value if not known
      */
-    @JsonProperty("unknown")
-    UNKNOWN,
+    UNKNOWN("unknown"),
 
     /**
      * An indirect reseller with a transaction role.
      */
-    @JsonProperty("transaction_reseller")
-    TRANSACTION_RESELLER
+    TRANSACTION_RESELLER("transaction_reseller");
+
+    private final String value;
+
+    ParticipantType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerPartnerRelationship.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerPartnerRelationship.java
@@ -6,43 +6,56 @@
 
 package com.microsoft.store.partnercenter.models.customers;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CustomerPartnerRelationship
 {
     /**
      *  Unknown. Used for initialization.
      */
-    @JsonProperty( "unknown" ) 
-    UNKNWON, 
-    
+    UNKNWON("unknown"),
+
     /**
      * None. Used to remove reseller relationship between the customer and partner.
      */
-    @JsonProperty( "none" ) 
-    NONE,
-    
+    NONE("none"),
+
     /**
      * The reseller relationship
      */
-    @JsonProperty( "reseller" ) 
-    RESELLER,
-    
+    RESELLER("reseller"),
+
     /**
      * The advisor relationship
      */
-    @JsonProperty( "advisor" ) 
-    ADVISOR,
-    
+    ADVISOR("advisor"),
+
     /**
      * Indicates that the partner is a syndication partner of the customer.
      */
-    @JsonProperty( "syndication" ) 
-    SYNDICATION,
-    
+    SYNDICATION("syndication"),
+
     /**
      * Indicates that the partner is a Microsoft Support agent for the customer.
      */
-    @JsonProperty( "microsoftSupport" ) 
-    MICROSOFT_SUPPORT
+    MICROSOFT_SUPPORT("microsoftSupport");
+
+    private final String value;
+
+    CustomerPartnerRelationship(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerQualification.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerQualification.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.customers;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * When a partner creates a new customer by default the customer is assigned "CustomerQualification.None". If the partner validates that the customer
@@ -18,18 +18,34 @@ public enum CustomerQualification
     /**
      * No Qualification
      */
-    @JsonProperty( "none" ) 
-    NONE,
+    NONE("none"),
 
     /**
      * Education Qualification
      */
-    @JsonProperty( "education" ) 
-    EDUCATION,
-    
+    EDUCATION("education"),
+
     /**
      *  Non-Profit / Charity Qualification
      */
-    @JsonProperty( "nonprofit" ) 
-    NONPROFIT
+    NONPROFIT("nonprofit");
+
+    private final String value;
+
+    CustomerQualification(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/customers/CustomerSearchField.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.store.partnercenter.models.customers;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * List of search fields for customer search
  */
@@ -14,26 +16,26 @@ public enum CustomerSearchField
     /**
      * Customer Company name
      */
-    COMPANY_NAME( "CompanyName" ), 
+    COMPANY_NAME("CompanyName"),
     
     /**
      * Customer domain name
      */
-    DOMAIN_NAME( "Domain" ),
+    DOMAIN_NAME("Domain"),
 
     /**
      * The indirect reseller
      */
-    INDIRECT_RESELLER( "IndirectReseller" ),
+    INDIRECT_RESELLER("IndirectReseller"),
 
     /**
      * The indirect CSP
      */
-    INDIRECT_CLOUD_SOLUTION_PROVIDER ( "IndirectCloudSolutionProvider" );
+    INDIRECT_CLOUD_SOLUTION_PROVIDER("IndirectCloudSolutionProvider");
 
     private String name;
 
-    private CustomerSearchField( String name )
+    CustomerSearchField(String name)
     {
         this.name = name;
     }
@@ -43,9 +45,10 @@ public enum CustomerSearchField
      * 
      * @return A string that represents this object.
      */
+    @JsonValue
     @Override
     public String toString()
     {
-        return this.name;
+        return name;
     }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/DeviceUploadStatusType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/DeviceUploadStatusType.java
@@ -6,39 +6,54 @@
 
 package com.microsoft.store.partnercenter.models.devicesdeployment;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  *  Devices Batch upload status.
  */
-public enum DeviceUploadStatusType {
-	/**
-	 *  Should never happen.
-	 */
-    @JsonProperty("unknown")
-    UNKNOWN,
+public enum DeviceUploadStatusType
+{
+    /**
+     * Should never happen.
+     */
+    UNKNOWN("unknown"),
 
     /**
      * Batch is queued.
      */
-    @JsonProperty("queued")
-    QUEUED,
+    QUEUED("queued"),
 
     /**
      * Batch is processing.
      */
-    @JsonProperty("processing")
-    PROCESSING,
+    PROCESSING("processing"),
 
     /**
      * Batch is complete.
      */
-    @JsonProperty("finished")
-    FINISHED,
+    FINISHED("finished"),
 
     /**
      * Batch is complete with an error.
      */
-    @JsonProperty("finished_with_errors")
-    FINISHED_WITH_ERRORS
+    FINISHED_WITH_ERRORS("finished_with_errors");
+
+    private final String value;
+
+    DeviceUploadStatusType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicyCategory.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicyCategory.java
@@ -6,21 +6,40 @@
 
 package com.microsoft.store.partnercenter.models.devicesdeployment;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents the policy type that can be assigned to a device.
  */
-public enum PolicyCategory {
+public enum PolicyCategory
+{
     /**
      * Default settings for the policy.
      */
-    @JsonProperty("none")
-    NONE,
+    NONE("none"),
 
     /**
      * OOBE - Out of box experience policy setting.
      */
-    @JsonProperty("o_o_b_e")
-    OOBE
+
+    OOBE("o_o_b_e");
+
+    private final String value;
+
+    PolicyCategory(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicySettingsType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicySettingsType.java
@@ -6,45 +6,59 @@
 
 package com.microsoft.store.partnercenter.models.devicesdeployment;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents the settings for an OOBE(Out of box experience) policy.
  */
-public enum PolicySettingsType {
+public enum PolicySettingsType
+{
     /**
      * Default value for policy settings.
      */
-    @JsonProperty("none")
-    None,
+    None("none"),
 
     /**
      * Remove OEM Pre-installs.
      */
-    @JsonProperty("remove_oem_preinstalls")
-    REMOVE_OEM_PREINSTALLS,
-    
+    REMOVE_OEM_PREINSTALLS("remove_oem_preinstalls"),
+
     /**
      * OOBE(Out of box experience) user will not be a local admin on the configured device.
      */
-    @JsonProperty("oobe_user_not_local_admin")
-    OOBE_USER_NOT_LOCAL_ADMIN,
+    OOBE_USER_NOT_LOCAL_ADMIN("oobe_user_not_local_admin"),
 
     /**
      * Skip express settings.
      */
-    @JsonProperty("skip_express_settings")
-    SKIP_EXPRESS_SETTINGS,
+    SKIP_EXPRESS_SETTINGS("skip_express_settings"),
 
     /**
      *  Skip OEM registration settings.
      */
-    @JsonProperty("skip_oem_registration")
-    SKIP_OEM_REGISTRATION,
+    SKIP_OEM_REGISTRATION("skip_oem_registration"),
 
     /**
      * Skip EULA settings.
      */
-    @JsonProperty("skip_eula")
-    SKIP_EULA
+    SKIP_EULA("skip_eula");
+
+    private final String value;
+
+    PolicySettingsType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/entitlements/ArtifactType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/entitlements/ArtifactType.java
@@ -6,27 +6,44 @@
 
 package com.microsoft.store.partnercenter.models.entitlements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * List of entitlement artifact types.
  */
-public enum ArtifactType {
+public enum ArtifactType
+{
     /**
      * Enum initializer.
      */
-    @JsonProperty("unknown")
-    UNKNOWN,
+    UNKNOWN("unknown"),
 
     /**
      * Entitlement artifact for a virtual machine reserved instance.
      */
-    @JsonProperty("virtual_machine_reserved_instance")
-    VIRTUAL_MACHINE_RESERVED_INSTANCE,
+    VIRTUAL_MACHINE_RESERVED_INSTANCE("virtual_machine_reserved_instance"),
 
     /**
      * Entitlement artifact for a product key.
      */
-    @JsonProperty("product_key")
-    PRODUCT_KEY
+    PRODUCT_KEY("product_key");
+
+    private final String value;
+
+    ArtifactType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/entitlements/EntitlementType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/entitlements/EntitlementType.java
@@ -6,27 +6,44 @@
 
 package com.microsoft.store.partnercenter.models.entitlements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * List of entitlement artifact types.
  */
-public enum EntitlementType {
+public enum EntitlementType
+{
     /**
      * Enum initializer.
      */
-    @JsonProperty("unknown")
-    UNKNOWN,
+    UNKNOWN("unknown"),
 
     /**
      * Virtual machine reserved instance entitlement.
      */
-    @JsonProperty("virtual_machine_reserved_instance")
-    VIRTUAL_MACHINE_RESERVED_INSTANCE,
+    VIRTUAL_MACHINE_RESERVED_INSTANCE("virtual_machine_reserved_instance"),
 
     /**
      * Software entitlement.
      */
-    @JsonProperty("software")
-    SOFTWARE
+    SOFTWARE("software");
+
+    private final String value;
+
+    EntitlementType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingProvider.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingProvider.java
@@ -6,37 +6,51 @@
 
 package com.microsoft.store.partnercenter.models.invoices;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum BillingProvider
 {
     /**
      * Different providers of billing information Enum initializer
      */
-    @JsonProperty( "none" )
-    NONE, 
-    
+    NONE("none"),
+
     /**
     * Bill is provided by Office. Example: O365, and In-tune.
     */
-    @JsonProperty( "office" )
-    OFFICE, 
-    
+    OFFICE("office"),
+
     /**
     * Bill is provided by Azure. Example: Azure Services.
     */
-    @JsonProperty( "azure" )
-    AZURE,
-    
+    AZURE("azure"),
+
     /**
     * Bill is provided by Azure Data Market.
     */
-    @JsonProperty( "azureDataMarket" )
-    AZURE_DATA_MARKET,
+    AZURE_DATA_MARKET("azureDataMarket"),
 
     /**
     * Bill is provided for one time purchases.
     */
-    @JsonProperty( "oneTime" ) 
-    ONE_TIME
+    ONE_TIME("oneTime");
+
+    private final String value;
+
+    BillingProvider(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingType.java
@@ -6,25 +6,41 @@
 
 package com.microsoft.store.partnercenter.models.invoices;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum BillingType
 {
     /**
      * The way billing is processed for a subscription Indicates nothing - not set, used as an initializer
      */
-    @JsonProperty( "none" ) 
-    NONE, 
-    
+    NONE("none"),
+
     /**
     * The usage based billing
     */
-    @JsonProperty( "usage" ) 
-    USAGE, 
-    
+    USAGE("usage"),
+
     /**
     * The license based billing
     */
-    @JsonProperty( "license" ) 
-    LICENSE
+    LICENSE("license");
+
+    private final String value;
+
+    BillingType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/DocumentType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/DocumentType.java
@@ -6,33 +6,49 @@
 
 package com.microsoft.store.partnercenter.models.invoices;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Different providers of billing information.
  */
-public enum DocumentType {
+public enum DocumentType
+{
     /**
      * Value if not set.
      */
-    @JsonProperty("none")
-    NONE,
+    NONE("none"),
 
     /**
      * Indicates that document type is an invoice.
      */
-    @JsonProperty("invoice")
-    INVOICE,
+    INVOICE("invoice"),
 
     /**
      * Indicates that document type is an void note.
      */
-    @JsonProperty("void_note")
-    VOID_NOTE,
+    VOID_NOTE("void_note"),
 
     /**
      * Indicates that document type is an adjustment note.
      */
-    @JsonProperty("adjustment_note")
-    ADJUSTMENT_NOTE
+    ADJUSTMENT_NOTE("adjustment_note");
+
+    private final String value;
+
+    DocumentType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/InvoiceSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/InvoiceSearchField.java
@@ -6,15 +6,34 @@
 
 package com.microsoft.store.partnercenter.models.invoices;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the supported invoice search fields.
  */
-public enum InvoiceSearchField {
+public enum InvoiceSearchField
+{
     /**
      * The invoice date.
      */
-    @JsonProperty("invoice_date")
-    INVOICE_DATE
+    INVOICE_DATE("invoice_date");
+
+    private final String value;
+
+    InvoiceSearchField(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/licenses/LicenseGroupId.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/licenses/LicenseGroupId.java
@@ -6,28 +6,45 @@
 
 package com.microsoft.store.partnercenter.models.licenses;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * License Group Id.
  */
-public enum LicenseGroupId {
-	/**
-	 * Indicates nothing - no type, used as an initializer. If any invalid value is 
+public enum LicenseGroupId
+{
+    /**
+     * Indicates nothing - no type, used as an initializer. If any invalid value is
      * passed, then it will be defaulted to this.
-	 */
-    @JsonProperty("none")
-    NONE,
+     */
+    NONE("none"),
 
     /**
      * Azure Active Directory This indicates that product SKU is managed by Azure AD.
      */
-    @JsonProperty("group1")
-    GROUP1,
+    GROUP1("group1"),
 
     /**
      * Store for Business This indicates that product SKU is not managed by Azure AD.
      */
-    @JsonProperty("group2")
-    GROUP2
+    GROUP2("group2");
+
+    private final String value;
+
+    LicenseGroupId(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/offers/BillingCycleType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/offers/BillingCycleType.java
@@ -6,40 +6,55 @@
 
 package com.microsoft.store.partnercenter.models.offers;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * The way billing is processed for a subscription.
  */
-public enum BillingCycleType {
-	/**
-	 * Enum initializer
-	 */
-    @JsonProperty("unknown")
-    UNKNOWN,
+public enum BillingCycleType
+{
+    /**
+     * Enum initializer
+     */
+    UNKNOWN("unknown"),
 
     /**
      * Indicates that the partner will be charged monthly for the subscription
      */
-    @JsonProperty("monthly")
-    MONTHLY,
+    MONTHLY("monthly"),
 
     /**
      * Indicates that the partner will be charged annually for the subscription.
      */
-    @JsonProperty("annual")
-    ANNUAL,
+    ANNUAL("annual"),
 
     /**
      * Indicates that the partner will be charged annually for the subscription.
      */
-    @JsonProperty("none")
-    NONE,
+    NONE("none"),
 
     /**
      * Indicates that the partner will be charged one-time This value does not apply
      * to all products.
      */
-    @JsonProperty("one_time")
-    ONE_TIME
+    ONE_TIME("one_time");
+
+    private final String value;
+
+    BillingCycleType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingStatus.java
@@ -6,30 +6,46 @@
 
 package com.microsoft.store.partnercenter.models.partners;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum VettingStatus {
+public enum VettingStatus
+{
     /**
      * None vetting status
      */
-    @JsonProperty( "none" ) 
-    NONE,
+    NONE("none"),
 
     /**
      * Pending vetting status
      */
-    @JsonProperty( "pending" ) 
-    PENDING,
+    PENDING("pending"),
 
     /**
      * Authorized vetting status
      */
-    @JsonProperty( "authorized" ) 
-    AUTHORIZED,
+    AUTHORIZED("authorized"),
 
     /**
      * Rejected vetting status
      */
-    @JsonProperty( "rejected" ) 
-    REJECTED
+    REJECTED("rejected");
+
+    private final String value;
+
+    VettingStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingSubStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingSubStatus.java
@@ -6,54 +6,66 @@
 
 package com.microsoft.store.partnercenter.models.partners;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum VettingSubStatus {
+public enum VettingSubStatus
+{
     /**
      * None vetting sub status
      */
-    @JsonProperty( "none" )
-    NONE,
+    NONE("none"),
 
     /**
      * The entry step
      */
-    @JsonProperty( "entry" ) 
-    ENTRY,
+    ENTRY("entry"),
 
     /**
      * Email ownership check for business accounts
      */
-    @JsonProperty( "email_ownership" ) 
-    EMAIL_OWNERSHIP,
+    EMAIL_OWNERSHIP("email_ownership"),
 
     /**
      * Email Domain for business accounts
      */
-    @JsonProperty( "email_domain" ) 
-    EMAIL_DOMAIN,
+    EMAIL_DOMAIN("email_domain"),
 
     /**
      * Employment verification sub status
      */
-    @JsonProperty( "employment_verification" ) 
-    EMPLOYMENT_VERIFICATION,
+    EMPLOYMENT_VERIFICATION("employment_verification"),
 
     /**
      * Decision making process
      */
-    @JsonProperty( "decision" ) 
-    DECISION,
+    DECISION("decision"),
 
     /**
      * Other vetting sub status
      */
-    @JsonProperty( "other" ) 
-    OTHER,
+    OTHER("other"),
 
     /**
      * Business verification sub status
      */
-    @JsonProperty( "business_verification" ) 
-    BUSINESS_VERIFICATION
+    BUSINESS_VERIFICATION("business_verification");
+
+    private final String value;
+
+    VettingSubStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingVersion.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/partners/VettingVersion.java
@@ -6,27 +6,43 @@
 
 package com.microsoft.store.partnercenter.models.partners;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum VettingVersion 
 {
     /**
      *  None vetting version
      */
-    @JsonProperty( "none" ) 
-    NONE,
+    NONE("none"),
 
     /**
      * Latest vetting information: Will always get the latest vetting information no
      * matter if it is vetted or not
      */
-    @JsonProperty( "current" ) 
-    CURRENT,
+    CURRENT("current"),
 
     /**
      * Latest finalized vetting information: Will return the latest vetting information
      * that is either (Authorized or Rejected)
      */
-    @JsonProperty( "last_finalized" ) 
-    LAST_FINALIZED
+    LAST_FINALIZED("last_finalized");
+
+    private final String value;
+
+    VettingVersion(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/products/BillingCycleType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/products/BillingCycleType.java
@@ -6,39 +6,54 @@
 
 package com.microsoft.store.partnercenter.models.products;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Types of Participants
  */
-public enum BillingCycleType {
+public enum BillingCycleType
+{
     /**
      * Default value if not known
      */
-    @JsonProperty("unknown")
-    UNKNOWN,
+    UNKNOWN("unknown"),
 
     /**
      * Indicates that the partner will be charged monthly.
      */
-    @JsonProperty("monthly")
-    MONTHLY,
+    MONTHLY("monthly"),
 
     /**
      * Indicates that the partner will be charged annuallu.
      */
-    @JsonProperty("annual")
-    ANNUAL,
+    ANNUAL("annual"),
 
     /**
      * Indicates that the partner will not be charged. This value is used for trial offers.
      */
-    @JsonProperty("none")
-    NONE,
+    NONE("none"),
 
     /**
      * Indicates that the partner will be charged one time. This value is used for modern product SKUs.
      */
-    @JsonProperty("one_time")
-    ONE_TIME
+    ONE_TIME("one_time");
+
+    private final String value;
+
+    BillingCycleType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/query/SeekOperation.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/query/SeekOperation.java
@@ -6,37 +6,51 @@
 
 package com.microsoft.store.partnercenter.models.query;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SeekOperation
 {
     /**
      * Specifies how to seek a query. Gets the next set of results.
      */
-    @JsonProperty( "Next" ) 
-    NEXT, 
-    
+    NEXT("Next"),
+
     /**
      * Gets the previous set of results.
      */
-    @JsonProperty( "Previous" ) 
-    PREVIOUS, 
-    
+    PREVIOUS("Previous"),
+
     /**
      * Gets the first set of results.
      */
-    @JsonProperty( "First" ) 
-    FIRST, 
-    
+    FIRST("First"),
+
     /**
      * Gets the last set of results.
      */
-    @JsonProperty( "Last" ) 
-    LAST, 
-    
+    LAST("Last"),
+
     /**
      * Gets a set of results using a page index. E.g. Get the seventh set of results.
      */
-    @JsonProperty( "PageIndex" ) 
-    PAGE_INDEX
+    PAGE_INDEX("PageIndex");
+
+    private final String value;
+
+    SeekOperation(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/query/filters/FieldFilterOperation.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/query/filters/FieldFilterOperation.java
@@ -6,72 +6,81 @@
 
 package com.microsoft.store.partnercenter.models.query.filters;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum FieldFilterOperation
 {
     /**
      * Enumerates supported filter operations. Equals filter.
      */
-    @JsonProperty( "Equals" ) 
-    EQUALS, 
-    
+    EQUALS("Equals"),
+
     /**
      * Not equals filter.
      */
-    @JsonProperty( "NotEquals" ) 
-    NOT_EQUALS, 
-    
+    NOT_EQUALS("NotEquals"),
+
     /**
      * Greater than filter.
      */
-    @JsonProperty( "GreaterThan" ) 
-    GREATER_THAN,
-    
+    GREATER_THAN("GreaterThan"),
+
     /**
      * Greater than or equal filter.
      */
-    @JsonProperty( "GreaterThanOrEquals" ) 
-    GREATER_THAN_OR_EQUALS, 
-    
+    GREATER_THAN_OR_EQUALS("GreaterThanOrEquals"),
+
     /**
      * Less than filter.
      */
-    @JsonProperty( "LessThan" )
-    LESS_THAN, 
-    
+    LESS_THAN("LessThan"),
+
     /**
      * Less than or equals filter.
      */
-    @JsonProperty( "LessThanOrEquals" ) 
-    LESS_THAN_OR_EQUALS, 
-    
+    LESS_THAN_OR_EQUALS("LessThanOrEquals"),
+
     /**
      * Substring filter.
      */
-    @JsonProperty( "Substring" ) 
-    SUBSTRING, 
-    
+    SUBSTRING("Substring"),
+
     /**
      * And filter.
      */
-    @JsonProperty( "And" ) 
-    AND, 
-    
+    AND("And"),
+
     /**
      * Or filter.
      */
-    @JsonProperty( "Or" ) OR, 
-    
+    OR("Or"),
+
     /**
      * String starts with filter.
      */
-    @JsonProperty( "StartsWith" ) 
-    STARTS_WITH, 
-    
+    STARTS_WITH("StartsWith"),
+
     /**
      * String does not starts with filter.
      */
-    @JsonProperty( "NotStartsWith" ) 
-    NOT_STARTS_WITH
+    NOT_STARTS_WITH("NotStartsWith");
+
+    private final String value;
+
+    FieldFilterOperation(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/query/filters/FieldType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/query/filters/FieldType.java
@@ -6,31 +6,46 @@
 
 package com.microsoft.store.partnercenter.models.query.filters;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum FieldType
 {
     /**
      * Enumerates supported field types. String Type
      */
-    @JsonProperty( "String" ) 
-    STRING, 
-    
+    STRING("String"),
+
     /**
      * Integer Type
      */
-    @JsonProperty( "Integer" ) 
-    INTEGER, 
-    
+    INTEGER("Integer"),
+
     /**
      * Enum Type
      */
-    @JsonProperty( "Enum" ) 
-    ENUM, 
-    
+    ENUM("Enum"),
+
     /**
      * DateTimeOffset Type
      */
-    @JsonProperty( "DateTimeOffset" ) 
-    DATE_TIME_OFFSET
+    DATE_TIME_OFFSET("DateTimeOffset");
+
+    private final String value;
+
+    FieldType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/query/sort/SortDirection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/query/sort/SortDirection.java
@@ -6,19 +6,36 @@
 
 package com.microsoft.store.partnercenter.models.query.sort;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SortDirection
 {
     /**
      * Sort direction enumeration. Ascending sort.
      */
-    @JsonProperty( "ascending" ) 
-    ASCENDING, 
-    
+    ASCENDING("ascending"),
+
     /**
      * Descending sort.
      */
-    @JsonProperty( "descending" ) 
-    DESCENDING
+    DESCENDING("descending");
+
+    private final String value;
+
+    SortDirection(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipSearchField.java
@@ -6,13 +6,31 @@
 
 package com.microsoft.store.partnercenter.models.relationships;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the supported partner relationship search fields.
  */
 public enum PartnerRelationshipSearchField 
 {
-    @JsonProperty("name")
-    NAME
+    NAME("name");
+
+    private final String value;
+
+    PartnerRelationshipSearchField(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipType.java
@@ -6,16 +6,39 @@
 
 package com.microsoft.store.partnercenter.models.relationships;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * The types of relationships between partners for two tier partner scenario.
  */
 public enum PartnerRelationshipType 
 {
-    @JsonProperty("is_indirect_reseller_of")
-    IS_INDIRECT_RESELLER_OF,
+    /**
+     * Is indirect reseller of.
+     */
+    IS_INDIRECT_RESELLER_OF("is_indirect_reseller_of"),
 
-    @JsonProperty("is_indirect_cloud_solution_provider_of")
-    IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF
+    /**
+     * Is indirect cloud solution provider of.
+     */
+    IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF("is_indirect_cloud_solution_provider_of");
+
+    private final String value;
+
+    PartnerRelationshipType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/servicecosts/ServiceCostsBillingPeriod.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/servicecosts/ServiceCostsBillingPeriod.java
@@ -6,18 +6,44 @@
 
 package com.microsoft.store.partnercenter.models.servicecosts;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents service costs billing periods.
  */
-public enum ServiceCostsBillingPeriod {
-    @JsonProperty("none")
-    NONE,
+public enum ServiceCostsBillingPeriod
+{
+    /**
+     * None.
+     */
+    NONE("none"),
 
-    @JsonProperty("most_recent")
-    MOST_RECENT,
+    /**
+     * Most recent.
+     */
+    MOST_RECENT("most_recent"),
 
-    @JsonProperty("current")
-    CURRENT
+    /**
+     * Current.
+     */
+    CURRENT("current");
+
+    private final String value;
+
+    ServiceCostsBillingPeriod(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/MessageType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/MessageType.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.serviceincidents;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents the status of partner center services.
@@ -16,24 +16,39 @@ public enum MessageType
     /**
      * Default type none.
      */
-    @JsonProperty( "none" ) 
-    NONE,
-	
+    NONE("none"),
+
     /**
      * Active incident.
      */
-    @JsonProperty( "incident" ) 
-    INCIDENT,
-	
+    INCIDENT("incident"),
+
     /**
      * Message center message.
      */
-    @JsonProperty( "message_center" ) 
-    MESSAGE_CENTER,
-	
+    MESSAGE_CENTER("message_center"),
+
     /**
      * All types.
      */
-    @JsonProperty( "all" ) 
-    ALL
+    ALL("all");
+
+    private final String value;
+
+    MessageType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentSearchField.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.serviceincidents;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the supported service incident search fields.
@@ -16,6 +16,24 @@ public enum ServiceIncidentSearchField
     /**
      * Search by service health incidents resolved status.
      */
-    @JsonProperty( "Resolved" ) 
-    RESOLVED
+    RESOLVED("Resolved");
+
+    private final String value;
+
+    ServiceIncidentSearchField(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentStatus.java
@@ -6,7 +6,7 @@
 
 package com.microsoft.store.partnercenter.models.serviceincidents;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Represents the status of partner center services.
@@ -16,24 +16,39 @@ public enum ServiceIncidentStatus
     /**
      * Default status - normal.
      */
-    @JsonProperty( "normal" ) 
-    NORMAL,
+    NORMAL("normal"),
 
     /**
      * Informational status.
      */
-    @JsonProperty( "information" ) 
-    INFORMATION,
+    INFORMATION("information"),
 
     /**
      * Warning status.
      */
-    @JsonProperty( "warning" ) 
-    WARNING,
+    WARNING("warning"),
 
     /**
      * Critical status.
      */
-    @JsonProperty( "critical" ) 
-    CRITICAL
+    CRITICAL("critical");
+
+    private final String value;
+
+    ServiceIncidentStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSearchField.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSearchField.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.store.partnercenter.models.servicerequests;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * Lists the supported service request search fields
  */
@@ -14,18 +16,24 @@ public enum ServiceRequestSearchField
     /**
      * Service request status
      */
-	STATUS( "Status" );
+    STATUS("Status");
 
-    private String name;
+    private String value;
 
-    private ServiceRequestSearchField( String name )
+    ServiceRequestSearchField(String value)
     {
-        this.name = name;
+        this.value = value;
     }
 
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
     @Override
     public String toString()
     {
-        return this.name;
+        return value;
     }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSeverity.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSeverity.java
@@ -6,31 +6,46 @@
 
 package com.microsoft.store.partnercenter.models.servicerequests;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ServiceRequestSeverity
 {
     /**
      * Describes service required status Severity Unknown
      */
-    @JsonProperty( "unknown" ) 
-    UNKNOWN, 
-    
+    UNKNOWN("unknown"),
+
     /**
      * Service Request Impact Critical
      */
-    @JsonProperty( "critical" ) 
-    CRITICAL, 
-    
+    CRITICAL("critical"),
+
     /**
      * Service Request Impact Moderate
      */
-    @JsonProperty( "moderate" ) 
-    MODERATE, 
-    
+    MODERATE("moderate"),
+
     /**
      * Service Request Impact Minimal
      */
-    @JsonProperty( "minimal" ) 
-    MINIMAL
+    MINIMAL("minimal");
+
+    private final String value;
+
+    ServiceRequestSeverity(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestStatus.java
@@ -6,31 +6,46 @@
 
 package com.microsoft.store.partnercenter.models.servicerequests;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ServiceRequestStatus
 {
     /**
      * Describes service request status Default Service Request Status
      */
-    @JsonProperty( "none" ) 
-    NONE, 
-    
+    NONE("none"),
+
     /**
      * Service Request Status Open
      */
-    @JsonProperty( "open" ) 
-    OPEN, 
-    
+    OPEN("open"),
+
     /**
      * Service Request Status Closed
      */
-    @JsonProperty( "closed" ) 
-    CLOSED, 
-    
+    CLOSED("closed"),
+
     /**
      * Service Request Status Action Required
      */
-    @JsonProperty( "attention_needed" ) 
-    ATTENTION_NEEDED
+    ATTENTION_NEEDED("attention_needed");
+
+    private final String value;
+
+    ServiceRequestStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/ConversionErrorCode.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/ConversionErrorCode.java
@@ -6,21 +6,49 @@
 
 package com.microsoft.store.partnercenter.models.subscriptions;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * The type of errors that prevent trial subscription conversion from happening.
  */
-public enum ConversionErrorCode {
-    @JsonProperty("other")
-    OTHER,
+public enum ConversionErrorCode
+{
+    /**
+     * Other.
+     */
+    OTHER("other"),
 
-    @JsonProperty("conversions_not_found")
-    CONVERSIONS_NOT_FOUND,
+    /**
+     * Conversions not found.
+     */
+    CONVERSIONS_NOT_FOUND("conversions_not_found"),
 
-    @JsonProperty("pending")
-    PENDING,
+    /**
+     * Pending.
+     */
+    PENDING("pending"),
 
-    @JsonProperty("failed")
-    FAILED
+    /**
+     * Failed.
+     */
+    FAILED("failed");
+
+    private final String value;
+
+    ConversionErrorCode(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/ProvisioningStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/ProvisioningStatus.java
@@ -6,22 +6,49 @@
 
 package com.microsoft.store.partnercenter.models.subscriptions;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the available status for a subscription provisioning status.
  */
 public enum ProvisioningStatus 
 {
-    @JsonProperty("none")
-    NONE,
+    /**
+     * None.
+     */
+    NONE("none"),
 
-    @JsonProperty("success")
-    SUCCESS,
+    /**
+     * Success.
+     */
+    SUCCESS("success"),
 
-    @JsonProperty("pending")
-    PENDING,
+    /**
+     * Pending.
+     */
+    PENDING("pending"),
 
-    @JsonProperty("failed")
-    FAILED
+    /**
+     * Failed.
+     */
+    FAILED("failed");
+
+    private final String value;
+
+    ProvisioningStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/SubscriptionStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/SubscriptionStatus.java
@@ -6,30 +6,46 @@
 
 package com.microsoft.store.partnercenter.models.subscriptions;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SubscriptionStatus
 {
     /**
      * Enum representing the available states for a subscription Indicates nothing - no status, used as an initializer
      */
-    @JsonProperty( "none" ) 
-    NONE, 
-    
+    NONE("none"),
+
     /**
      * Subscription state: Active
      */
-    @JsonProperty( "active" ) 
-    ACTIVE, 
-    
+    ACTIVE("active"),
+
     /**
      * Subscription state: Suspended
      */
-    @JsonProperty( "suspended" ) 
-    SUSPENDED, 
-    
+    SUSPENDED("suspended"),
+
     /**
      * Subscription state: Deleted
      */
-    @JsonProperty( "deleted" ) DELETED
+    DELETED("deleted");
+
+    private final String value;
+
+    SubscriptionStatus(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeErrorCode.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeErrorCode.java
@@ -6,68 +6,77 @@
 
 package com.microsoft.store.partnercenter.models.subscriptions;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum UpgradeErrorCode
 {
     /**
      * The type of errors that prevent subscription upgrading from happening General error.
      */
-    @JsonProperty( "Other" ) 
-    OTHER,
-    
+    OTHER("Other"),
+
     /**
      * Upgrade cannot be performed because administrative permissions have been removed.
      */
-    @JsonProperty( "DelegatedAdminPermissionsDisabled" ) 
-    DELEGATED_ADMIN_PERMISSIONS_DISABLED,
-    
+    DELEGATED_ADMIN_PERMISSIONS_DISABLED("DelegatedAdminPermissionsDisabled"),
+
     /**
      * Upgrade cannot be performed because the subscription status is suspended or deleted.
      */
-    @JsonProperty( "SubscriptionStatusNotActive" ) 
-    SUBSCRIPTION_STATUS_NOT_ACTIVE,
-    
+    SUBSCRIPTION_STATUS_NOT_ACTIVE("SubscriptionStatusNotActive"),
+
     /**
      * Upgrade cannot be performed because of conflicting source service types.
      */
-    @JsonProperty( "ConflictingServiceTypes" ) 
-    CONFLICTING_SERVICE_TYPES,
-    
+    CONFLICTING_SERVICE_TYPES("ConflictingServiceTypes"),
+
     /**
      * Upgrade cannot be performed due to concurrent subscription restrictions.
      */
-    @JsonProperty( "ConcurrencyConflicts" ) 
-    CONCURRENCY_CONFLICTS,
-    
+    CONCURRENCY_CONFLICTS("ConcurrencyConflicts"),
+
     /**
      * Upgrade cannot be performed because the current request is using app context.
      */
-    @JsonProperty( "UserContextRequired" ) 
-    USER_CONTEXT_REQUIRED,
-    
+    USER_CONTEXT_REQUIRED("UserContextRequired"),
+
     /**
      * Upgrade cannot be performed because the source subscription has previously purchased add-ons.
      */
-    @JsonProperty( "SubscriptionAddOnsPresent" ) 
-    SUBSCRIPTION_ADD_ONS_PRESENT,
-    
+    SUBSCRIPTION_ADD_ONS_PRESENT("SubscriptionAddOnsPresent"),
+
     /**
      * Upgrade cannot be performed because the source subscription does not have upgrade paths.
      */
-    @JsonProperty( "SubscriptionDoesNotHaveAnyUpgradePaths" ) 
-    SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS,
-    
+    SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS("SubscriptionDoesNotHaveAnyUpgradePaths"),
+
     /**
      * Upgrade cannot be performed because the specified upgrade path is not an available upgrade path.
      */
-    @JsonProperty( "SubscriptionTargetOfferNotFound" ) 
-    SUBSCRIPTION_TARGET_OFFER_NOT_FOUND,
-    
+    SUBSCRIPTION_TARGET_OFFER_NOT_FOUND("SubscriptionTargetOfferNotFound"),
+
     /**
      * The subscription is not provisioned yet. Happens when the order is still being processed. Eventually the
      * subscription ill be provisioned and an entitlement is created.
      */
-    @JsonProperty( "SubscriptionNotProvisioned" ) 
-    SUBSCRIPTION_NOT_PROVISIONED
+    SUBSCRIPTION_NOT_PROVISIONED("SubscriptionNotProvisioned");
+
+    private final String value;
+
+    UpgradeErrorCode(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeType.java
@@ -6,25 +6,41 @@
 
 package com.microsoft.store.partnercenter.models.subscriptions;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum UpgradeType
 {
     /**
      * Represents a form of upgrade for a subscription Default value
      */
-    @JsonProperty( "none" ) 
-    NONE, 
-    
+    NONE("none"),
+
     /**
      * Only subscription upgrade
      */
-    @JsonProperty( "upgrade_only" ) 
-    UPGRADE_ONLY, 
-    
+    UPGRADE_ONLY("upgrade_only"),
+
     /**
      * Subscription upgrade and license transfer
      */
-    @JsonProperty( "upgrade_with_license_transfer" ) 
-    UPGRADE_WITH_LICENSE_TRANSFER
+    UPGRADE_WITH_LICENSE_TRANSFER("upgrade_with_license_transfer");
+
+    private final String value;
+
+    UpgradeType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/users/UserDomainType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/users/UserDomainType.java
@@ -6,31 +6,47 @@
 
 package com.microsoft.store.partnercenter.models.users;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Types of user domains supported.
  */
 public enum UserDomainType 
 {
-	/**
-	  * Default - None.
-	  */
-	 @JsonProperty("none")
-	 NONE,
+    /**
+     * Default - None.
+     */
+    NONE("none"),
 
-	 /**
-	  * Password sync directories support mixed mode 
-	  * i.e. users that are cloud only or directory synced from an on premises directory.
-	  */
-	 @JsonProperty("managed")
-	 MANAGED,
+    /**
+     * Password sync directories support mixed mode
+     * i.e. users that are cloud only or directory synced from an on premises directory.
+     */
+    MANAGED("managed"),
 
-	 /**
-	  * Federated domains don’t support mixed mode. 
-	  * Users created have to be linked to an on premises directory account 
-	  * with their immutable ids.
-	  */
-	 @JsonProperty("federated")
-	 FEDERATED
+    /**
+     * Federated domains don’t support mixed mode.
+     * Users created have to be linked to an on premises directory account
+     * with their immutable ids.
+     */
+    FEDERATED("federated");
+
+    private final String value;
+
+    UserDomainType(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/users/UserState.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/users/UserState.java
@@ -6,22 +6,39 @@
 
 package com.microsoft.store.partnercenter.models.users;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * User state
  */
 public enum UserState 
 {
-	 /**
-	  * Active user.
-	  */
-	 @JsonProperty("active")
-	 ACTIVE,
+    /**
+     * Active user.
+     */
+    ACTIVE("active"),
 
-	 /**
-	  * Inactive user.
-	  */
-	 @JsonProperty("inactive")
-	 INACTIVE
+    /**
+     * Inactive user.
+     */
+    INACTIVE("inactive");
+
+    private final String value;
+
+    UserState(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/utilizations/AzureUtilizationGranularity.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/utilizations/AzureUtilizationGranularity.java
@@ -6,22 +6,39 @@
 
 package com.microsoft.store.partnercenter.models.utilizations;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * Lists the time granularity options for retrieving A subscription's azure utilization.
  */
 public enum AzureUtilizationGranularity
 {
-	/**
-	 * Daily utilization.
-	 */
-    @JsonProperty("daily")
-	DAILY,
-	
-	/**
-	 * Hourly utilization.
-	 */
-    @JsonProperty("hourly")
-	HOURLY
+    /**
+     * Daily utilization.
+     */
+    DAILY("daily"),
+
+    /**
+     * Hourly utilization.
+     */
+    HOURLY("hourly");
+
+    private final String value;
+
+    AzureUtilizationGranularity(String value)
+    {
+        this.value = value;
+    }
+
+    /**
+     * Converts the object to a string.
+     *
+     * @return A string that represents this object.
+     */
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return value;
+    }
 }

--- a/src/test/java/com/microsoft/store/partnercenter/TestJsonConverter.java
+++ b/src/test/java/com/microsoft/store/partnercenter/TestJsonConverter.java
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="TestJsonConverter.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 package com.microsoft.store.partnercenter;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/test/java/com/microsoft/store/partnercenter/models/ContractTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/ContractTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="ContractTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ContractTypeTest
+{
+    private static final String SUBSCRIPTION_VALUE = "subscription";
+    private static final String PRODUCTKEY_VALUE = "productkey";
+    private static final String REDEMPTIONCODE_VALUE = "redemptioncode";
+    private static final String SUBSCRIPTION_JSON = '"' + SUBSCRIPTION_VALUE + '"';
+    private static final String PRODUCTKEY_JSON = '"' + PRODUCTKEY_VALUE + '"';
+    private static final String REDEMPTIONCODE_JSON = '"' + REDEMPTIONCODE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ContractType.SUBSCRIPTION, jsonConverter.readValue(SUBSCRIPTION_JSON, ContractType.class));
+        assertEquals(ContractType.PRODUCTKEY, jsonConverter.readValue(PRODUCTKEY_JSON, ContractType.class));
+        assertEquals(ContractType.REDEMPTIONCODE, jsonConverter.readValue(REDEMPTIONCODE_JSON, ContractType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(SUBSCRIPTION_JSON, jsonConverter.writeValueAsString(ContractType.SUBSCRIPTION));
+        assertEquals(PRODUCTKEY_JSON, jsonConverter.writeValueAsString(ContractType.PRODUCTKEY));
+        assertEquals(REDEMPTIONCODE_JSON, jsonConverter.writeValueAsString(ContractType.REDEMPTIONCODE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(SUBSCRIPTION_VALUE, ContractType.SUBSCRIPTION.toString());
+        assertEquals(PRODUCTKEY_VALUE, ContractType.PRODUCTKEY.toString());
+        assertEquals(REDEMPTIONCODE_VALUE, ContractType.REDEMPTIONCODE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/agreements/AgreementTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/agreements/AgreementTypeTest.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgreementTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.agreements;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AgreementTypeTest
+{
+    private static final String MICROSOFT_CLOUD_AGREEMENT_VALUE = "MicrosoftCloudAgreement";
+    private static final String MICROSOFT_CLOUD_AGREEMENT_JSON = '"' + MICROSOFT_CLOUD_AGREEMENT_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(AgreementType.MICROSOFT_CLOUD_AGREEMENT, jsonConverter.readValue(MICROSOFT_CLOUD_AGREEMENT_JSON, AgreementType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(MICROSOFT_CLOUD_AGREEMENT_JSON, jsonConverter.writeValueAsString(AgreementType.MICROSOFT_CLOUD_AGREEMENT));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(MICROSOFT_CLOUD_AGREEMENT_VALUE, AgreementType.MICROSOFT_CLOUD_AGREEMENT.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/auditing/AuditRecordSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/auditing/AuditRecordSearchFieldTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuditRecordSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.auditing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuditRecordSearchFieldTest
+{
+    private static final String COMPANY_NAME_VALUE = "CompanyName";
+    private static final String CUSTOMER_ID_VALUE = "CustomerId";
+    private static final String RESOURCE_TYPE_VALUE = "ResourceType";
+    private static final String COMPANY_NAME_JSON = '"' + COMPANY_NAME_VALUE + '"';
+    private static final String CUSTOMER_ID_JSON = '"' + CUSTOMER_ID_VALUE + '"';
+    private static final String RESOURCE_TYPE_JSON = '"' + RESOURCE_TYPE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(AuditRecordSearchField.COMPANY_NAME, jsonConverter.readValue(COMPANY_NAME_JSON, AuditRecordSearchField.class));
+        assertEquals(AuditRecordSearchField.CUSTOMER_ID, jsonConverter.readValue(CUSTOMER_ID_JSON, AuditRecordSearchField.class));
+        assertEquals(AuditRecordSearchField.RESOURCE_TYPE, jsonConverter.readValue(RESOURCE_TYPE_JSON, AuditRecordSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(COMPANY_NAME_JSON, jsonConverter.writeValueAsString(AuditRecordSearchField.COMPANY_NAME));
+        assertEquals(CUSTOMER_ID_JSON, jsonConverter.writeValueAsString(AuditRecordSearchField.CUSTOMER_ID));
+        assertEquals(RESOURCE_TYPE_JSON, jsonConverter.writeValueAsString(AuditRecordSearchField.RESOURCE_TYPE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(COMPANY_NAME_VALUE, AuditRecordSearchField.COMPANY_NAME.toString());
+        assertEquals(CUSTOMER_ID_VALUE, AuditRecordSearchField.CUSTOMER_ID.toString());
+        assertEquals(RESOURCE_TYPE_VALUE, AuditRecordSearchField.RESOURCE_TYPE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/auditing/OperationStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/auditing/OperationStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="OperationStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.auditing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OperationStatusTest
+{
+    private static final String SUCCEEDED_VALUE = "succeeded";
+    private static final String FAILED_VALUE = "failed";
+    private static final String PROGRESS_VALUE = "progress";
+    private static final String DECLINE_VALUE = "decline";
+    private static final String SUCCEEDED_JSON = '"' + SUCCEEDED_VALUE + '"';
+    private static final String FAILED_JSON = '"' + FAILED_VALUE + '"';
+    private static final String PROGRESS_JSON = '"' + PROGRESS_VALUE + '"';
+    private static final String DECLINE_JSON = '"' + DECLINE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(OperationStatus.SUCCEEDED, jsonConverter.readValue(SUCCEEDED_JSON, OperationStatus.class));
+        assertEquals(OperationStatus.FAILED, jsonConverter.readValue(FAILED_JSON, OperationStatus.class));
+        assertEquals(OperationStatus.PROGRESS, jsonConverter.readValue(PROGRESS_JSON, OperationStatus.class));
+        assertEquals(OperationStatus.DECLINE, jsonConverter.readValue(DECLINE_JSON, OperationStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(SUCCEEDED_JSON, jsonConverter.writeValueAsString(OperationStatus.SUCCEEDED));
+        assertEquals(FAILED_JSON, jsonConverter.writeValueAsString(OperationStatus.FAILED));
+        assertEquals(PROGRESS_JSON, jsonConverter.writeValueAsString(OperationStatus.PROGRESS));
+        assertEquals(DECLINE_JSON, jsonConverter.writeValueAsString(OperationStatus.DECLINE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(SUCCEEDED_VALUE, OperationStatus.SUCCEEDED.toString());
+        assertEquals(FAILED_VALUE, OperationStatus.FAILED.toString());
+        assertEquals(PROGRESS_VALUE, OperationStatus.PROGRESS.toString());
+        assertEquals(DECLINE_VALUE, OperationStatus.DECLINE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/auditing/OperationTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/auditing/OperationTypeTest.java
@@ -1,0 +1,203 @@
+// -----------------------------------------------------------------------
+// <copyright file="OperationTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.auditing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OperationTypeTest
+{
+    private static final String UNDEFINED_VALUE = "undefined";
+    private static final String UPDATE_CUSTOMER_QUALIFICATION_VALUE = "update_customer_qualification";
+    private static final String UPDATE_SUBSCRIPTION_VALUE = "update_subscription";
+    private static final String UPGRADE_SUBSCRIPTION_VALUE = "upgrade_subscription";
+    private static final String CONVERT_TRIAL_SUBSCRIPTION_VALUE = "convert_trial_subscription";
+    private static final String ADD_CUSTOMER_VALUE = "add_customer";
+    private static final String UPDATE_CUSTOMER_BILLING_PROFILE_VALUE = "update_customer_billing_profile";
+    private static final String UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_VALUE = "update_customer_partner_contract_company_Name";
+    private static final String UPDATECUSTOMERSPENDINGBUDGET_VALUE = "update_Customer_spending_budget";
+    private static final String DELETE_CUSTOMER_VALUE = "delete_customer";
+    private static final String REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_VALUE = "remove_partner_customer_relationship";
+    private static final String CREATE_ORDER_VALUE = "create_order";
+    private static final String UPDATE_ORDER_VALUE = "update_order";
+    private static final String CREATE_CUSTOMER_USER_VALUE = "create_customer_user";
+    private static final String DELETE_CUSTOMER_USER_VALUE = "delete_customer_user";
+    private static final String UPDATE_CUSTOMER_USER_VALUE = "update_customer_user";
+    private static final String UPDATE_CUSTOMER_USER_LICENSES_VALUE = "Update_customer_user_licenses";
+    private static final String RESET_CUSTOMER_USER_PASSWORD_VALUE = "reset_customer_user_password";
+    private static final String UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_VALUE = "update_customer_user_principal_name";
+    private static final String RESTORE_CUSTOMER_USER_VALUE = "restore_customer_user";
+    private static final String CREATE_MPN_ASSOCIATION_VALUE = "create_mpn_association";
+    private static final String UPDATE_MPN_ASSOCIATION_VALUE = "update_mpn_association";
+    private static final String UPDATE_SFB_CUSTOMER_USER_LICENSES_VALUE = "update_sfb_customer_user_licenses";
+    private static final String UPDATE_TRANSFER_VALUE = "update_transfer";
+    private static final String CREATE_PARTNER_RELATIONSHIP_VALUE = "create_partner_relationship";
+    private static final String REGISTER_APPLICATION_VALUE = "register_application";
+    private static final String UNREGISTER_APPLICATION_VALUE = "unregister_application";
+    private static final String ADD_APPLICATION_CREDENTIAL_VALUE = "add_application_credential";
+    private static final String REMOVE_APPLICATION_CREDENTIAL_VALUE = "remove_application_credential";
+    private static final String CREATE_PARTNER_USER_VALUE = "create_partner_user";
+    private static final String UPDATE_PARTNER_USER_VALUE = "update_partner_user";
+    private static final String remove_partner_user_VALUE = "Remove_partner_user";
+    private static final String UNDEFINED_JSON = '"' + UNDEFINED_VALUE + '"';
+    private static final String UPDATE_CUSTOMER_QUALIFICATION_JSON = '"' + UPDATE_CUSTOMER_QUALIFICATION_VALUE + '"';
+    private static final String UPDATE_SUBSCRIPTION_JSON = '"' + UPDATE_SUBSCRIPTION_VALUE + '"';
+    private static final String UPGRADE_SUBSCRIPTION_JSON = '"' + UPGRADE_SUBSCRIPTION_VALUE + '"';
+    private static final String CONVERT_TRIAL_SUBSCRIPTION_JSON = '"' + CONVERT_TRIAL_SUBSCRIPTION_VALUE + '"';
+    private static final String ADD_CUSTOMER_JSON = '"' + ADD_CUSTOMER_VALUE + '"';
+    private static final String UPDATE_CUSTOMER_BILLING_PROFILE_JSON = '"' + UPDATE_CUSTOMER_BILLING_PROFILE_VALUE + '"';
+    private static final String UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_JSON = '"' + UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_VALUE + '"';
+    private static final String UPDATECUSTOMERSPENDINGBUDGET_JSON = '"' + UPDATECUSTOMERSPENDINGBUDGET_VALUE + '"';
+    private static final String DELETE_CUSTOMER_JSON = '"' + DELETE_CUSTOMER_VALUE + '"';
+    private static final String REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_JSON = '"' + REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_VALUE + '"';
+    private static final String CREATE_ORDER_JSON = '"' + CREATE_ORDER_VALUE + '"';
+    private static final String UPDATE_ORDER_JSON = '"' + UPDATE_ORDER_VALUE + '"';
+    private static final String CREATE_CUSTOMER_USER_JSON = '"' + CREATE_CUSTOMER_USER_VALUE + '"';
+    private static final String DELETE_CUSTOMER_USER_JSON = '"' + DELETE_CUSTOMER_USER_VALUE + '"';
+    private static final String UPDATE_CUSTOMER_USER_JSON = '"' + UPDATE_CUSTOMER_USER_VALUE + '"';
+    private static final String UPDATE_CUSTOMER_USER_LICENSES_JSON = '"' + UPDATE_CUSTOMER_USER_LICENSES_VALUE + '"';
+    private static final String RESET_CUSTOMER_USER_PASSWORD_JSON = '"' + RESET_CUSTOMER_USER_PASSWORD_VALUE + '"';
+    private static final String UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_JSON = '"' + UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_VALUE + '"';
+    private static final String RESTORE_CUSTOMER_USER_JSON = '"' + RESTORE_CUSTOMER_USER_VALUE + '"';
+    private static final String CREATE_MPN_ASSOCIATION_JSON = '"' + CREATE_MPN_ASSOCIATION_VALUE + '"';
+    private static final String UPDATE_MPN_ASSOCIATION_JSON = '"' + UPDATE_MPN_ASSOCIATION_VALUE + '"';
+    private static final String UPDATE_SFB_CUSTOMER_USER_LICENSES_JSON = '"' + UPDATE_SFB_CUSTOMER_USER_LICENSES_VALUE + '"';
+    private static final String UPDATE_TRANSFER_JSON = '"' + UPDATE_TRANSFER_VALUE + '"';
+    private static final String CREATE_PARTNER_RELATIONSHIP_JSON = '"' + CREATE_PARTNER_RELATIONSHIP_VALUE + '"';
+    private static final String REGISTER_APPLICATION_JSON = '"' + REGISTER_APPLICATION_VALUE + '"';
+    private static final String UNREGISTER_APPLICATION_JSON = '"' + UNREGISTER_APPLICATION_VALUE + '"';
+    private static final String ADD_APPLICATION_CREDENTIAL_JSON = '"' + ADD_APPLICATION_CREDENTIAL_VALUE + '"';
+    private static final String REMOVE_APPLICATION_CREDENTIAL_JSON = '"' + REMOVE_APPLICATION_CREDENTIAL_VALUE + '"';
+    private static final String CREATE_PARTNER_USER_JSON = '"' + CREATE_PARTNER_USER_VALUE + '"';
+    private static final String UPDATE_PARTNER_USER_JSON = '"' + UPDATE_PARTNER_USER_VALUE + '"';
+    private static final String remove_partner_user_JSON = '"' + remove_partner_user_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(OperationType.UNDEFINED, jsonConverter.readValue(UNDEFINED_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_CUSTOMER_QUALIFICATION, jsonConverter.readValue(UPDATE_CUSTOMER_QUALIFICATION_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_SUBSCRIPTION, jsonConverter.readValue(UPDATE_SUBSCRIPTION_JSON, OperationType.class));
+        assertEquals(OperationType.UPGRADE_SUBSCRIPTION, jsonConverter.readValue(UPGRADE_SUBSCRIPTION_JSON, OperationType.class));
+        assertEquals(OperationType.CONVERT_TRIAL_SUBSCRIPTION, jsonConverter.readValue(CONVERT_TRIAL_SUBSCRIPTION_JSON, OperationType.class));
+        assertEquals(OperationType.ADD_CUSTOMER, jsonConverter.readValue(ADD_CUSTOMER_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_CUSTOMER_BILLING_PROFILE, jsonConverter.readValue(UPDATE_CUSTOMER_BILLING_PROFILE_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME, jsonConverter.readValue(UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATECUSTOMERSPENDINGBUDGET, jsonConverter.readValue(UPDATECUSTOMERSPENDINGBUDGET_JSON, OperationType.class));
+        assertEquals(OperationType.DELETE_CUSTOMER, jsonConverter.readValue(DELETE_CUSTOMER_JSON, OperationType.class));
+        assertEquals(OperationType.REMOVE_PARTNER_CUSTOMER_RELATIONSHIP, jsonConverter.readValue(REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_JSON, OperationType.class));
+        assertEquals(OperationType.CREATE_ORDER, jsonConverter.readValue(CREATE_ORDER_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_ORDER, jsonConverter.readValue(UPDATE_ORDER_JSON, OperationType.class));
+        assertEquals(OperationType.CREATE_CUSTOMER_USER, jsonConverter.readValue(CREATE_CUSTOMER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.DELETE_CUSTOMER_USER, jsonConverter.readValue(DELETE_CUSTOMER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_CUSTOMER_USER, jsonConverter.readValue(UPDATE_CUSTOMER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_CUSTOMER_USER_LICENSES, jsonConverter.readValue(UPDATE_CUSTOMER_USER_LICENSES_JSON, OperationType.class));
+        assertEquals(OperationType.RESET_CUSTOMER_USER_PASSWORD, jsonConverter.readValue(RESET_CUSTOMER_USER_PASSWORD_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_CUSTOMER_USER_PRINCIPAL_NAME, jsonConverter.readValue(UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_JSON, OperationType.class));
+        assertEquals(OperationType.RESTORE_CUSTOMER_USER, jsonConverter.readValue(RESTORE_CUSTOMER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.CREATE_MPN_ASSOCIATION, jsonConverter.readValue(CREATE_MPN_ASSOCIATION_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_MPN_ASSOCIATION, jsonConverter.readValue(UPDATE_MPN_ASSOCIATION_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_SFB_CUSTOMER_USER_LICENSES, jsonConverter.readValue(UPDATE_SFB_CUSTOMER_USER_LICENSES_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_TRANSFER, jsonConverter.readValue(UPDATE_TRANSFER_JSON, OperationType.class));
+        assertEquals(OperationType.CREATE_PARTNER_RELATIONSHIP, jsonConverter.readValue(CREATE_PARTNER_RELATIONSHIP_JSON, OperationType.class));
+        assertEquals(OperationType.REGISTER_APPLICATION, jsonConverter.readValue(REGISTER_APPLICATION_JSON, OperationType.class));
+        assertEquals(OperationType.UNREGISTER_APPLICATION, jsonConverter.readValue(UNREGISTER_APPLICATION_JSON, OperationType.class));
+        assertEquals(OperationType.ADD_APPLICATION_CREDENTIAL, jsonConverter.readValue(ADD_APPLICATION_CREDENTIAL_JSON, OperationType.class));
+        assertEquals(OperationType.REMOVE_APPLICATION_CREDENTIAL, jsonConverter.readValue(REMOVE_APPLICATION_CREDENTIAL_JSON, OperationType.class));
+        assertEquals(OperationType.CREATE_PARTNER_USER, jsonConverter.readValue(CREATE_PARTNER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.UPDATE_PARTNER_USER, jsonConverter.readValue(UPDATE_PARTNER_USER_JSON, OperationType.class));
+        assertEquals(OperationType.remove_partner_user, jsonConverter.readValue(remove_partner_user_JSON, OperationType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNDEFINED_JSON, jsonConverter.writeValueAsString(OperationType.UNDEFINED));
+        assertEquals(UPDATE_CUSTOMER_QUALIFICATION_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_CUSTOMER_QUALIFICATION));
+        assertEquals(UPDATE_SUBSCRIPTION_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_SUBSCRIPTION));
+        assertEquals(UPGRADE_SUBSCRIPTION_JSON, jsonConverter.writeValueAsString(OperationType.UPGRADE_SUBSCRIPTION));
+        assertEquals(CONVERT_TRIAL_SUBSCRIPTION_JSON, jsonConverter.writeValueAsString(OperationType.CONVERT_TRIAL_SUBSCRIPTION));
+        assertEquals(ADD_CUSTOMER_JSON, jsonConverter.writeValueAsString(OperationType.ADD_CUSTOMER));
+        assertEquals(UPDATE_CUSTOMER_BILLING_PROFILE_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_CUSTOMER_BILLING_PROFILE));
+        assertEquals(UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_JSON, jsonConverter.writeValueAsString(OperationType.UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME));
+        assertEquals(UPDATECUSTOMERSPENDINGBUDGET_JSON, jsonConverter.writeValueAsString(OperationType.UPDATECUSTOMERSPENDINGBUDGET));
+        assertEquals(DELETE_CUSTOMER_JSON, jsonConverter.writeValueAsString(OperationType.DELETE_CUSTOMER));
+        assertEquals(REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_JSON, jsonConverter.writeValueAsString(OperationType.REMOVE_PARTNER_CUSTOMER_RELATIONSHIP));
+        assertEquals(CREATE_ORDER_JSON, jsonConverter.writeValueAsString(OperationType.CREATE_ORDER));
+        assertEquals(UPDATE_ORDER_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_ORDER));
+        assertEquals(CREATE_CUSTOMER_USER_JSON, jsonConverter.writeValueAsString(OperationType.CREATE_CUSTOMER_USER));
+        assertEquals(DELETE_CUSTOMER_USER_JSON, jsonConverter.writeValueAsString(OperationType.DELETE_CUSTOMER_USER));
+        assertEquals(UPDATE_CUSTOMER_USER_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_CUSTOMER_USER));
+        assertEquals(UPDATE_CUSTOMER_USER_LICENSES_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_CUSTOMER_USER_LICENSES));
+        assertEquals(RESET_CUSTOMER_USER_PASSWORD_JSON, jsonConverter.writeValueAsString(OperationType.RESET_CUSTOMER_USER_PASSWORD));
+        assertEquals(UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_CUSTOMER_USER_PRINCIPAL_NAME));
+        assertEquals(RESTORE_CUSTOMER_USER_JSON, jsonConverter.writeValueAsString(OperationType.RESTORE_CUSTOMER_USER));
+        assertEquals(CREATE_MPN_ASSOCIATION_JSON, jsonConverter.writeValueAsString(OperationType.CREATE_MPN_ASSOCIATION));
+        assertEquals(UPDATE_MPN_ASSOCIATION_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_MPN_ASSOCIATION));
+        assertEquals(UPDATE_SFB_CUSTOMER_USER_LICENSES_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_SFB_CUSTOMER_USER_LICENSES));
+        assertEquals(UPDATE_TRANSFER_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_TRANSFER));
+        assertEquals(CREATE_PARTNER_RELATIONSHIP_JSON, jsonConverter.writeValueAsString(OperationType.CREATE_PARTNER_RELATIONSHIP));
+        assertEquals(REGISTER_APPLICATION_JSON, jsonConverter.writeValueAsString(OperationType.REGISTER_APPLICATION));
+        assertEquals(UNREGISTER_APPLICATION_JSON, jsonConverter.writeValueAsString(OperationType.UNREGISTER_APPLICATION));
+        assertEquals(ADD_APPLICATION_CREDENTIAL_JSON, jsonConverter.writeValueAsString(OperationType.ADD_APPLICATION_CREDENTIAL));
+        assertEquals(REMOVE_APPLICATION_CREDENTIAL_JSON, jsonConverter.writeValueAsString(OperationType.REMOVE_APPLICATION_CREDENTIAL));
+        assertEquals(CREATE_PARTNER_USER_JSON, jsonConverter.writeValueAsString(OperationType.CREATE_PARTNER_USER));
+        assertEquals(UPDATE_PARTNER_USER_JSON, jsonConverter.writeValueAsString(OperationType.UPDATE_PARTNER_USER));
+        assertEquals(remove_partner_user_JSON, jsonConverter.writeValueAsString(OperationType.remove_partner_user));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNDEFINED_VALUE, OperationType.UNDEFINED.toString());
+        assertEquals(UPDATE_CUSTOMER_QUALIFICATION_VALUE, OperationType.UPDATE_CUSTOMER_QUALIFICATION.toString());
+        assertEquals(UPDATE_SUBSCRIPTION_VALUE, OperationType.UPDATE_SUBSCRIPTION.toString());
+        assertEquals(UPGRADE_SUBSCRIPTION_VALUE, OperationType.UPGRADE_SUBSCRIPTION.toString());
+        assertEquals(CONVERT_TRIAL_SUBSCRIPTION_VALUE, OperationType.CONVERT_TRIAL_SUBSCRIPTION.toString());
+        assertEquals(ADD_CUSTOMER_VALUE, OperationType.ADD_CUSTOMER.toString());
+        assertEquals(UPDATE_CUSTOMER_BILLING_PROFILE_VALUE, OperationType.UPDATE_CUSTOMER_BILLING_PROFILE.toString());
+        assertEquals(UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME_VALUE, OperationType.UPDATECUSTOMERPARTNERCONTRACTCOMPANYNAME.toString());
+        assertEquals(UPDATECUSTOMERSPENDINGBUDGET_VALUE, OperationType.UPDATECUSTOMERSPENDINGBUDGET.toString());
+        assertEquals(DELETE_CUSTOMER_VALUE, OperationType.DELETE_CUSTOMER.toString());
+        assertEquals(REMOVE_PARTNER_CUSTOMER_RELATIONSHIP_VALUE, OperationType.REMOVE_PARTNER_CUSTOMER_RELATIONSHIP.toString());
+        assertEquals(CREATE_ORDER_VALUE, OperationType.CREATE_ORDER.toString());
+        assertEquals(UPDATE_ORDER_VALUE, OperationType.UPDATE_ORDER.toString());
+        assertEquals(CREATE_CUSTOMER_USER_VALUE, OperationType.CREATE_CUSTOMER_USER.toString());
+        assertEquals(DELETE_CUSTOMER_USER_VALUE, OperationType.DELETE_CUSTOMER_USER.toString());
+        assertEquals(UPDATE_CUSTOMER_USER_VALUE, OperationType.UPDATE_CUSTOMER_USER.toString());
+        assertEquals(UPDATE_CUSTOMER_USER_LICENSES_VALUE, OperationType.UPDATE_CUSTOMER_USER_LICENSES.toString());
+        assertEquals(RESET_CUSTOMER_USER_PASSWORD_VALUE, OperationType.RESET_CUSTOMER_USER_PASSWORD.toString());
+        assertEquals(UPDATE_CUSTOMER_USER_PRINCIPAL_NAME_VALUE, OperationType.UPDATE_CUSTOMER_USER_PRINCIPAL_NAME.toString());
+        assertEquals(RESTORE_CUSTOMER_USER_VALUE, OperationType.RESTORE_CUSTOMER_USER.toString());
+        assertEquals(CREATE_MPN_ASSOCIATION_VALUE, OperationType.CREATE_MPN_ASSOCIATION.toString());
+        assertEquals(UPDATE_MPN_ASSOCIATION_VALUE, OperationType.UPDATE_MPN_ASSOCIATION.toString());
+        assertEquals(UPDATE_SFB_CUSTOMER_USER_LICENSES_VALUE, OperationType.UPDATE_SFB_CUSTOMER_USER_LICENSES.toString());
+        assertEquals(UPDATE_TRANSFER_VALUE, OperationType.UPDATE_TRANSFER.toString());
+        assertEquals(CREATE_PARTNER_RELATIONSHIP_VALUE, OperationType.CREATE_PARTNER_RELATIONSHIP.toString());
+        assertEquals(REGISTER_APPLICATION_VALUE, OperationType.REGISTER_APPLICATION.toString());
+        assertEquals(UNREGISTER_APPLICATION_VALUE, OperationType.UNREGISTER_APPLICATION.toString());
+        assertEquals(ADD_APPLICATION_CREDENTIAL_VALUE, OperationType.ADD_APPLICATION_CREDENTIAL.toString());
+        assertEquals(REMOVE_APPLICATION_CREDENTIAL_VALUE, OperationType.REMOVE_APPLICATION_CREDENTIAL.toString());
+        assertEquals(CREATE_PARTNER_USER_VALUE, OperationType.CREATE_PARTNER_USER.toString());
+        assertEquals(UPDATE_PARTNER_USER_VALUE, OperationType.UPDATE_PARTNER_USER.toString());
+        assertEquals(remove_partner_user_VALUE, OperationType.remove_partner_user.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/auditing/ResourceTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/auditing/ResourceTypeTest.java
@@ -1,0 +1,107 @@
+// -----------------------------------------------------------------------
+// <copyright file="ResourceTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.auditing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ResourceTypeTest
+{
+    private static final String UNDEFINED_VALUE = "undefined";
+    private static final String CUSTOMER_VALUE = "customer";
+    private static final String CUSTOMER_USER_VALUE = "customer_user";
+    private static final String ORDER_VALUE = "order";
+    private static final String SUBSCRIPTION_VALUE = "subscription";
+    private static final String LICENSE_VALUE = "license";
+    private static final String THIRD_PARTY_ADD_ON_VALUE = "third_party_add_on";
+    private static final String MPN_ASSOCIATION_VALUE = "mpn_association";
+    private static final String TRANSFER_VALUE = "transfer";
+    private static final String APPLICATION_VALUE = "application";
+    private static final String APPLICATION_CREDENTIAL_VALUE = "application_credential";
+    private static final String PARTNER_USER_VALUE = "partner_user";
+    private static final String PARTNER_RELATIONSHIP_VALUE = "partner_relationship";
+    private static final String UNDEFINED_JSON = '"' + UNDEFINED_VALUE + '"';
+    private static final String CUSTOMER_JSON = '"' + CUSTOMER_VALUE + '"';
+    private static final String CUSTOMER_USER_JSON = '"' + CUSTOMER_USER_VALUE + '"';
+    private static final String ORDER_JSON = '"' + ORDER_VALUE + '"';
+    private static final String SUBSCRIPTION_JSON = '"' + SUBSCRIPTION_VALUE + '"';
+    private static final String LICENSE_JSON = '"' + LICENSE_VALUE + '"';
+    private static final String THIRD_PARTY_ADD_ON_JSON = '"' + THIRD_PARTY_ADD_ON_VALUE + '"';
+    private static final String MPN_ASSOCIATION_JSON = '"' + MPN_ASSOCIATION_VALUE + '"';
+    private static final String TRANSFER_JSON = '"' + TRANSFER_VALUE + '"';
+    private static final String APPLICATION_JSON = '"' + APPLICATION_VALUE + '"';
+    private static final String APPLICATION_CREDENTIAL_JSON = '"' + APPLICATION_CREDENTIAL_VALUE + '"';
+    private static final String PARTNER_USER_JSON = '"' + PARTNER_USER_VALUE + '"';
+    private static final String PARTNER_RELATIONSHIP_JSON = '"' + PARTNER_RELATIONSHIP_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ResourceType.UNDEFINED, jsonConverter.readValue(UNDEFINED_JSON, ResourceType.class));
+        assertEquals(ResourceType.CUSTOMER, jsonConverter.readValue(CUSTOMER_JSON, ResourceType.class));
+        assertEquals(ResourceType.CUSTOMER_USER, jsonConverter.readValue(CUSTOMER_USER_JSON, ResourceType.class));
+        assertEquals(ResourceType.ORDER, jsonConverter.readValue(ORDER_JSON, ResourceType.class));
+        assertEquals(ResourceType.SUBSCRIPTION, jsonConverter.readValue(SUBSCRIPTION_JSON, ResourceType.class));
+        assertEquals(ResourceType.LICENSE, jsonConverter.readValue(LICENSE_JSON, ResourceType.class));
+        assertEquals(ResourceType.THIRD_PARTY_ADD_ON, jsonConverter.readValue(THIRD_PARTY_ADD_ON_JSON, ResourceType.class));
+        assertEquals(ResourceType.MPN_ASSOCIATION, jsonConverter.readValue(MPN_ASSOCIATION_JSON, ResourceType.class));
+        assertEquals(ResourceType.TRANSFER, jsonConverter.readValue(TRANSFER_JSON, ResourceType.class));
+        assertEquals(ResourceType.APPLICATION, jsonConverter.readValue(APPLICATION_JSON, ResourceType.class));
+        assertEquals(ResourceType.APPLICATION_CREDENTIAL, jsonConverter.readValue(APPLICATION_CREDENTIAL_JSON, ResourceType.class));
+        assertEquals(ResourceType.PARTNER_USER, jsonConverter.readValue(PARTNER_USER_JSON, ResourceType.class));
+        assertEquals(ResourceType.PARTNER_RELATIONSHIP, jsonConverter.readValue(PARTNER_RELATIONSHIP_JSON, ResourceType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNDEFINED_JSON, jsonConverter.writeValueAsString(ResourceType.UNDEFINED));
+        assertEquals(CUSTOMER_JSON, jsonConverter.writeValueAsString(ResourceType.CUSTOMER));
+        assertEquals(CUSTOMER_USER_JSON, jsonConverter.writeValueAsString(ResourceType.CUSTOMER_USER));
+        assertEquals(ORDER_JSON, jsonConverter.writeValueAsString(ResourceType.ORDER));
+        assertEquals(SUBSCRIPTION_JSON, jsonConverter.writeValueAsString(ResourceType.SUBSCRIPTION));
+        assertEquals(LICENSE_JSON, jsonConverter.writeValueAsString(ResourceType.LICENSE));
+        assertEquals(THIRD_PARTY_ADD_ON_JSON, jsonConverter.writeValueAsString(ResourceType.THIRD_PARTY_ADD_ON));
+        assertEquals(MPN_ASSOCIATION_JSON, jsonConverter.writeValueAsString(ResourceType.MPN_ASSOCIATION));
+        assertEquals(TRANSFER_JSON, jsonConverter.writeValueAsString(ResourceType.TRANSFER));
+        assertEquals(APPLICATION_JSON, jsonConverter.writeValueAsString(ResourceType.APPLICATION));
+        assertEquals(APPLICATION_CREDENTIAL_JSON, jsonConverter.writeValueAsString(ResourceType.APPLICATION_CREDENTIAL));
+        assertEquals(PARTNER_USER_JSON, jsonConverter.writeValueAsString(ResourceType.PARTNER_USER));
+        assertEquals(PARTNER_RELATIONSHIP_JSON, jsonConverter.writeValueAsString(ResourceType.PARTNER_RELATIONSHIP));
+    }
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNDEFINED_VALUE, ResourceType.UNDEFINED.toString());
+        assertEquals(CUSTOMER_VALUE, ResourceType.CUSTOMER.toString());
+        assertEquals(CUSTOMER_USER_VALUE, ResourceType.CUSTOMER_USER.toString());
+        assertEquals(ORDER_VALUE, ResourceType.ORDER.toString());
+        assertEquals(SUBSCRIPTION_VALUE, ResourceType.SUBSCRIPTION.toString());
+        assertEquals(LICENSE_VALUE, ResourceType.LICENSE.toString());
+        assertEquals(THIRD_PARTY_ADD_ON_VALUE, ResourceType.THIRD_PARTY_ADD_ON.toString());
+        assertEquals(MPN_ASSOCIATION_VALUE, ResourceType.MPN_ASSOCIATION.toString());
+        assertEquals(TRANSFER_VALUE, ResourceType.TRANSFER.toString());
+        assertEquals(APPLICATION_VALUE, ResourceType.APPLICATION.toString());
+        assertEquals(APPLICATION_CREDENTIAL_VALUE, ResourceType.APPLICATION_CREDENTIAL.toString());
+        assertEquals(PARTNER_USER_VALUE, ResourceType.PARTNER_USER.toString());
+        assertEquals(PARTNER_RELATIONSHIP_VALUE, ResourceType.PARTNER_RELATIONSHIP.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/carts/CartErrorTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/carts/CartErrorTest.java
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="CartErrorTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 package com.microsoft.store.partnercenter.models.carts;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/microsoft/store/partnercenter/models/carts/ParticipantTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/carts/ParticipantTypeTest.java
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="ParticipantTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.carts;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ParticipantTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String TRANSACTION_RESELLER_VALUE = "transaction_reseller";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String TRANSACTION_RESELLER_JSON = '"' + TRANSACTION_RESELLER_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ParticipantType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, ParticipantType.class));
+        assertEquals(ParticipantType.TRANSACTION_RESELLER, jsonConverter.readValue(TRANSACTION_RESELLER_JSON, ParticipantType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(ParticipantType.UNKNOWN));
+        assertEquals(TRANSACTION_RESELLER_JSON, jsonConverter.writeValueAsString(ParticipantType.TRANSACTION_RESELLER));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, ParticipantType.UNKNOWN.toString());
+        assertEquals(TRANSACTION_RESELLER_VALUE, ParticipantType.TRANSACTION_RESELLER.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerPartnerRelationshipTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerPartnerRelationshipTest.java
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="CustomerPartnerRelationshipTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.customers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomerPartnerRelationshipTest
+{
+    private static final String UNKNWON_VALUE = "unknown";
+    private static final String NONE_VALUE = "none";
+    private static final String RESELLER_VALUE = "reseller";
+    private static final String ADVISOR_VALUE = "advisor";
+    private static final String SYNDICATION_VALUE = "syndication";
+    private static final String MICROSOFT_SUPPORT_VALUE = "microsoftSupport";
+    private static final String UNKNWON_JSON = '"' + UNKNWON_VALUE + '"';
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String RESELLER_JSON = '"' + RESELLER_VALUE + '"';
+    private static final String ADVISOR_JSON = '"' + ADVISOR_VALUE + '"';
+    private static final String SYNDICATION_JSON = '"' + SYNDICATION_VALUE + '"';
+    private static final String MICROSOFT_SUPPORT_JSON = '"' + MICROSOFT_SUPPORT_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(CustomerPartnerRelationship.UNKNWON, jsonConverter.readValue(UNKNWON_JSON, CustomerPartnerRelationship.class));
+        assertEquals(CustomerPartnerRelationship.NONE, jsonConverter.readValue(NONE_JSON, CustomerPartnerRelationship.class));
+        assertEquals(CustomerPartnerRelationship.RESELLER, jsonConverter.readValue(RESELLER_JSON, CustomerPartnerRelationship.class));
+        assertEquals(CustomerPartnerRelationship.ADVISOR, jsonConverter.readValue(ADVISOR_JSON, CustomerPartnerRelationship.class));
+        assertEquals(CustomerPartnerRelationship.SYNDICATION, jsonConverter.readValue(SYNDICATION_JSON, CustomerPartnerRelationship.class));
+        assertEquals(CustomerPartnerRelationship.MICROSOFT_SUPPORT, jsonConverter.readValue(MICROSOFT_SUPPORT_JSON, CustomerPartnerRelationship.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNWON_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.UNKNWON));
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.NONE));
+        assertEquals(RESELLER_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.RESELLER));
+        assertEquals(ADVISOR_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.ADVISOR));
+        assertEquals(SYNDICATION_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.SYNDICATION));
+        assertEquals(MICROSOFT_SUPPORT_JSON, jsonConverter.writeValueAsString(CustomerPartnerRelationship.MICROSOFT_SUPPORT));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNWON_VALUE, CustomerPartnerRelationship.UNKNWON.toString());
+        assertEquals(NONE_VALUE, CustomerPartnerRelationship.NONE.toString());
+        assertEquals(RESELLER_VALUE, CustomerPartnerRelationship.RESELLER.toString());
+        assertEquals(ADVISOR_VALUE, CustomerPartnerRelationship.ADVISOR.toString());
+        assertEquals(SYNDICATION_VALUE, CustomerPartnerRelationship.SYNDICATION.toString());
+        assertEquals(MICROSOFT_SUPPORT_VALUE, CustomerPartnerRelationship.MICROSOFT_SUPPORT.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerQualificationTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerQualificationTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="CustomerQualificationTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.customers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomerQualificationTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String EDUCATION_VALUE = "education";
+    private static final String NONPROFIT_VALUE = "nonprofit";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String EDUCATION_JSON = '"' + EDUCATION_VALUE + '"';
+    private static final String NONPROFIT_JSON = '"' + NONPROFIT_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(CustomerQualification.NONE, jsonConverter.readValue(NONE_JSON, CustomerQualification.class));
+        assertEquals(CustomerQualification.EDUCATION, jsonConverter.readValue(EDUCATION_JSON, CustomerQualification.class));
+        assertEquals(CustomerQualification.NONPROFIT, jsonConverter.readValue(NONPROFIT_JSON, CustomerQualification.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(CustomerQualification.NONE));
+        assertEquals(EDUCATION_JSON, jsonConverter.writeValueAsString(CustomerQualification.EDUCATION));
+        assertEquals(NONPROFIT_JSON, jsonConverter.writeValueAsString(CustomerQualification.NONPROFIT));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, CustomerQualification.NONE.toString());
+        assertEquals(EDUCATION_VALUE, CustomerQualification.EDUCATION.toString());
+        assertEquals(NONPROFIT_VALUE, CustomerQualification.NONPROFIT.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/customers/CustomerSearchFieldTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="CustomerSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.customers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CustomerSearchFieldTest
+{
+    private static final String COMPANY_NAME_VALUE = "CompanyName";
+    private static final String DOMAIN_NAME_VALUE = "Domain";
+    private static final String INDIRECT_RESELLER_VALUE = "IndirectReseller";
+    private static final String INDIRECT_CLOUD_SOLUTION_PROVIDER_VALUE = "IndirectCloudSolutionProvider";
+    private static final String COMPANY_NAME_JSON = '"' + COMPANY_NAME_VALUE + '"';
+    private static final String DOMAIN_NAME_JSON = '"' + DOMAIN_NAME_VALUE + '"';
+    private static final String INDIRECT_RESELLER_JSON = '"' + INDIRECT_RESELLER_VALUE + '"';
+    private static final String INDIRECT_CLOUD_SOLUTION_PROVIDER_JSON = '"' + INDIRECT_CLOUD_SOLUTION_PROVIDER_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(CustomerSearchField.COMPANY_NAME, jsonConverter.readValue(COMPANY_NAME_JSON, CustomerSearchField.class));
+        assertEquals(CustomerSearchField.DOMAIN_NAME, jsonConverter.readValue(DOMAIN_NAME_JSON, CustomerSearchField.class));
+        assertEquals(CustomerSearchField.INDIRECT_RESELLER, jsonConverter.readValue(INDIRECT_RESELLER_JSON, CustomerSearchField.class));
+        assertEquals(CustomerSearchField.INDIRECT_CLOUD_SOLUTION_PROVIDER, jsonConverter.readValue(INDIRECT_CLOUD_SOLUTION_PROVIDER_JSON, CustomerSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(COMPANY_NAME_JSON, jsonConverter.writeValueAsString(CustomerSearchField.COMPANY_NAME));
+        assertEquals(DOMAIN_NAME_JSON, jsonConverter.writeValueAsString(CustomerSearchField.DOMAIN_NAME));
+        assertEquals(INDIRECT_RESELLER_JSON, jsonConverter.writeValueAsString(CustomerSearchField.INDIRECT_RESELLER));
+        assertEquals(INDIRECT_CLOUD_SOLUTION_PROVIDER_JSON, jsonConverter.writeValueAsString(CustomerSearchField.INDIRECT_CLOUD_SOLUTION_PROVIDER));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(COMPANY_NAME_VALUE, CustomerSearchField.COMPANY_NAME.toString());
+        assertEquals(DOMAIN_NAME_VALUE, CustomerSearchField.DOMAIN_NAME.toString());
+        assertEquals(INDIRECT_RESELLER_VALUE, CustomerSearchField.INDIRECT_RESELLER.toString());
+        assertEquals(INDIRECT_CLOUD_SOLUTION_PROVIDER_VALUE, CustomerSearchField.INDIRECT_CLOUD_SOLUTION_PROVIDER.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/DeviceUploadStatusTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/DeviceUploadStatusTypeTest.java
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeviceUploadStatusTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.devicesdeployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeviceUploadStatusTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String QUEUED_VALUE = "queued";
+    private static final String PROCESSING_VALUE = "processing";
+    private static final String FINISHED_VALUE = "finished";
+    private static final String FINISHED_WITH_ERRORS_VALUE = "finished_with_errors";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String QUEUED_JSON = '"' + QUEUED_VALUE + '"';
+    private static final String PROCESSING_JSON = '"' + PROCESSING_VALUE + '"';
+    private static final String FINISHED_JSON = '"' + FINISHED_VALUE + '"';
+    private static final String FINISHED_WITH_ERRORS_JSON = '"' + FINISHED_WITH_ERRORS_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(DeviceUploadStatusType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, DeviceUploadStatusType.class));
+        assertEquals(DeviceUploadStatusType.QUEUED, jsonConverter.readValue(QUEUED_JSON, DeviceUploadStatusType.class));
+        assertEquals(DeviceUploadStatusType.PROCESSING, jsonConverter.readValue(PROCESSING_JSON, DeviceUploadStatusType.class));
+        assertEquals(DeviceUploadStatusType.FINISHED, jsonConverter.readValue(FINISHED_JSON, DeviceUploadStatusType.class));
+        assertEquals(DeviceUploadStatusType.FINISHED_WITH_ERRORS, jsonConverter.readValue(FINISHED_WITH_ERRORS_JSON, DeviceUploadStatusType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(DeviceUploadStatusType.UNKNOWN));
+        assertEquals(QUEUED_JSON, jsonConverter.writeValueAsString(DeviceUploadStatusType.QUEUED));
+        assertEquals(PROCESSING_JSON, jsonConverter.writeValueAsString(DeviceUploadStatusType.PROCESSING));
+        assertEquals(FINISHED_JSON, jsonConverter.writeValueAsString(DeviceUploadStatusType.FINISHED));
+        assertEquals(FINISHED_WITH_ERRORS_JSON, jsonConverter.writeValueAsString(DeviceUploadStatusType.FINISHED_WITH_ERRORS));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, DeviceUploadStatusType.UNKNOWN.toString());
+        assertEquals(QUEUED_VALUE, DeviceUploadStatusType.QUEUED.toString());
+        assertEquals(PROCESSING_VALUE, DeviceUploadStatusType.PROCESSING.toString());
+        assertEquals(FINISHED_VALUE, DeviceUploadStatusType.FINISHED.toString());
+        assertEquals(FINISHED_WITH_ERRORS_VALUE, DeviceUploadStatusType.FINISHED_WITH_ERRORS.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicyCategoryTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicyCategoryTest.java
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="PolicyCategoryTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.devicesdeployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PolicyCategoryTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String OOBE_VALUE = "o_o_b_e";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String OOBE_JSON = '"' + OOBE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(PolicyCategory.NONE, jsonConverter.readValue(NONE_JSON, PolicyCategory.class));
+        assertEquals(PolicyCategory.OOBE, jsonConverter.readValue(OOBE_JSON, PolicyCategory.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(PolicyCategory.NONE));
+        assertEquals(OOBE_JSON, jsonConverter.writeValueAsString(PolicyCategory.OOBE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, PolicyCategory.NONE.toString());
+        assertEquals(OOBE_VALUE, PolicyCategory.OOBE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicySettingsTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/devicesdeployment/PolicySettingsTypeTest.java
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="PolicySettingsTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.devicesdeployment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PolicySettingsTypeTest
+{
+    private static final String None_VALUE = "none";
+    private static final String REMOVE_OEM_PREINSTALLS_VALUE = "remove_oem_preinstalls";
+    private static final String OOBE_USER_NOT_LOCAL_ADMIN_VALUE = "oobe_user_not_local_admin";
+    private static final String SKIP_EXPRESS_SETTINGS_VALUE = "skip_express_settings";
+    private static final String SKIP_OEM_REGISTRATION_VALUE = "skip_oem_registration";
+    private static final String SKIP_EULA_VALUE = "skip_eula";
+    private static final String None_JSON = '"' + None_VALUE + '"';
+    private static final String REMOVE_OEM_PREINSTALLS_JSON = '"' + REMOVE_OEM_PREINSTALLS_VALUE + '"';
+    private static final String OOBE_USER_NOT_LOCAL_ADMIN_JSON = '"' + OOBE_USER_NOT_LOCAL_ADMIN_VALUE + '"';
+    private static final String SKIP_EXPRESS_SETTINGS_JSON = '"' + SKIP_EXPRESS_SETTINGS_VALUE + '"';
+    private static final String SKIP_OEM_REGISTRATION_JSON = '"' + SKIP_OEM_REGISTRATION_VALUE + '"';
+    private static final String SKIP_EULA_JSON = '"' + SKIP_EULA_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(PolicySettingsType.None, jsonConverter.readValue(None_JSON, PolicySettingsType.class));
+        assertEquals(PolicySettingsType.REMOVE_OEM_PREINSTALLS, jsonConverter.readValue(REMOVE_OEM_PREINSTALLS_JSON, PolicySettingsType.class));
+        assertEquals(PolicySettingsType.OOBE_USER_NOT_LOCAL_ADMIN, jsonConverter.readValue(OOBE_USER_NOT_LOCAL_ADMIN_JSON, PolicySettingsType.class));
+        assertEquals(PolicySettingsType.SKIP_EXPRESS_SETTINGS, jsonConverter.readValue(SKIP_EXPRESS_SETTINGS_JSON, PolicySettingsType.class));
+        assertEquals(PolicySettingsType.SKIP_OEM_REGISTRATION, jsonConverter.readValue(SKIP_OEM_REGISTRATION_JSON, PolicySettingsType.class));
+        assertEquals(PolicySettingsType.SKIP_EULA, jsonConverter.readValue(SKIP_EULA_JSON, PolicySettingsType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(None_JSON, jsonConverter.writeValueAsString(PolicySettingsType.None));
+        assertEquals(REMOVE_OEM_PREINSTALLS_JSON, jsonConverter.writeValueAsString(PolicySettingsType.REMOVE_OEM_PREINSTALLS));
+        assertEquals(OOBE_USER_NOT_LOCAL_ADMIN_JSON, jsonConverter.writeValueAsString(PolicySettingsType.OOBE_USER_NOT_LOCAL_ADMIN));
+        assertEquals(SKIP_EXPRESS_SETTINGS_JSON, jsonConverter.writeValueAsString(PolicySettingsType.SKIP_EXPRESS_SETTINGS));
+        assertEquals(SKIP_OEM_REGISTRATION_JSON, jsonConverter.writeValueAsString(PolicySettingsType.SKIP_OEM_REGISTRATION));
+        assertEquals(SKIP_EULA_JSON, jsonConverter.writeValueAsString(PolicySettingsType.SKIP_EULA));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(None_VALUE, PolicySettingsType.None.toString());
+        assertEquals(REMOVE_OEM_PREINSTALLS_VALUE, PolicySettingsType.REMOVE_OEM_PREINSTALLS.toString());
+        assertEquals(OOBE_USER_NOT_LOCAL_ADMIN_VALUE, PolicySettingsType.OOBE_USER_NOT_LOCAL_ADMIN.toString());
+        assertEquals(SKIP_EXPRESS_SETTINGS_VALUE, PolicySettingsType.SKIP_EXPRESS_SETTINGS.toString());
+        assertEquals(SKIP_OEM_REGISTRATION_VALUE, PolicySettingsType.SKIP_OEM_REGISTRATION.toString());
+        assertEquals(SKIP_EULA_VALUE, PolicySettingsType.SKIP_EULA.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/entitlements/ArtifactTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/entitlements/ArtifactTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="ArtifactTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.entitlements;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtifactTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE = "virtual_machine_reserved_instance";
+    private static final String PRODUCT_KEY_VALUE = "product_key";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON = '"' + VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE + '"';
+    private static final String PRODUCT_KEY_JSON = '"' + PRODUCT_KEY_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ArtifactType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, ArtifactType.class));
+        assertEquals(ArtifactType.VIRTUAL_MACHINE_RESERVED_INSTANCE, jsonConverter.readValue(VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON, ArtifactType.class));
+        assertEquals(ArtifactType.PRODUCT_KEY, jsonConverter.readValue(PRODUCT_KEY_JSON, ArtifactType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(ArtifactType.UNKNOWN));
+        assertEquals(VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON, jsonConverter.writeValueAsString(ArtifactType.VIRTUAL_MACHINE_RESERVED_INSTANCE));
+        assertEquals(PRODUCT_KEY_JSON, jsonConverter.writeValueAsString(ArtifactType.PRODUCT_KEY));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, ArtifactType.UNKNOWN.toString());
+        assertEquals(VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE, ArtifactType.VIRTUAL_MACHINE_RESERVED_INSTANCE.toString());
+        assertEquals(PRODUCT_KEY_VALUE, ArtifactType.PRODUCT_KEY.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/entitlements/EntitlementTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/entitlements/EntitlementTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="EntitlementTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.entitlements;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EntitlementTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE = "virtual_machine_reserved_instance";
+    private static final String SOFTWARE_VALUE = "software";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON = '"' + VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE + '"';
+    private static final String SOFTWARE_JSON = '"' + SOFTWARE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(EntitlementType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, EntitlementType.class));
+        assertEquals(EntitlementType.VIRTUAL_MACHINE_RESERVED_INSTANCE, jsonConverter.readValue(VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON, EntitlementType.class));
+        assertEquals(EntitlementType.SOFTWARE, jsonConverter.readValue(SOFTWARE_JSON, EntitlementType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(EntitlementType.UNKNOWN));
+        assertEquals(VIRTUAL_MACHINE_RESERVED_INSTANCE_JSON, jsonConverter.writeValueAsString(EntitlementType.VIRTUAL_MACHINE_RESERVED_INSTANCE));
+        assertEquals(SOFTWARE_JSON, jsonConverter.writeValueAsString(EntitlementType.SOFTWARE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, EntitlementType.UNKNOWN.toString());
+        assertEquals(VIRTUAL_MACHINE_RESERVED_INSTANCE_VALUE, EntitlementType.VIRTUAL_MACHINE_RESERVED_INSTANCE.toString());
+        assertEquals(SOFTWARE_VALUE, EntitlementType.SOFTWARE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingProviderTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingProviderTest.java
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingProviderTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.invoices;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BillingProviderTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String OFFICE_VALUE = "office";
+    private static final String AZURE_VALUE = "azure";
+    private static final String AZURE_DATA_MARKET_VALUE = "azureDataMarket";
+    private static final String ONE_TIME_VALUE = "oneTime";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String OFFICE_JSON = '"' + OFFICE_VALUE + '"';
+    private static final String AZURE_JSON = '"' + AZURE_VALUE + '"';
+    private static final String AZURE_DATA_MARKET_JSON = '"' + AZURE_DATA_MARKET_VALUE + '"';
+    private static final String ONE_TIME_JSON = '"' + ONE_TIME_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(BillingProvider.NONE, jsonConverter.readValue(NONE_JSON, BillingProvider.class));
+        assertEquals(BillingProvider.OFFICE, jsonConverter.readValue(OFFICE_JSON, BillingProvider.class));
+        assertEquals(BillingProvider.AZURE, jsonConverter.readValue(AZURE_JSON, BillingProvider.class));
+        assertEquals(BillingProvider.AZURE_DATA_MARKET, jsonConverter.readValue(AZURE_DATA_MARKET_JSON, BillingProvider.class));
+        assertEquals(BillingProvider.ONE_TIME, jsonConverter.readValue(ONE_TIME_JSON, BillingProvider.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(BillingProvider.NONE));
+        assertEquals(OFFICE_JSON, jsonConverter.writeValueAsString(BillingProvider.OFFICE));
+        assertEquals(AZURE_JSON, jsonConverter.writeValueAsString(BillingProvider.AZURE));
+        assertEquals(AZURE_DATA_MARKET_JSON, jsonConverter.writeValueAsString(BillingProvider.AZURE_DATA_MARKET));
+        assertEquals(ONE_TIME_JSON, jsonConverter.writeValueAsString(BillingProvider.ONE_TIME));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, BillingProvider.NONE.toString());
+        assertEquals(OFFICE_VALUE, BillingProvider.OFFICE.toString());
+        assertEquals(AZURE_VALUE, BillingProvider.AZURE.toString());
+        assertEquals(AZURE_DATA_MARKET_VALUE, BillingProvider.AZURE_DATA_MARKET.toString());
+        assertEquals(ONE_TIME_VALUE, BillingProvider.ONE_TIME.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.invoices;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BillingTypeTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String USAGE_VALUE = "usage";
+    private static final String LICENSE_VALUE = "license";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String USAGE_JSON = '"' + USAGE_VALUE + '"';
+    private static final String LICENSE_JSON = '"' + LICENSE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(BillingType.NONE, jsonConverter.readValue(NONE_JSON, BillingType.class));
+        assertEquals(BillingType.USAGE, jsonConverter.readValue(USAGE_JSON, BillingType.class));
+        assertEquals(BillingType.LICENSE, jsonConverter.readValue(LICENSE_JSON, BillingType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(BillingType.NONE));
+        assertEquals(USAGE_JSON, jsonConverter.writeValueAsString(BillingType.USAGE));
+        assertEquals(LICENSE_JSON, jsonConverter.writeValueAsString(BillingType.LICENSE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, BillingType.NONE.toString());
+        assertEquals(USAGE_VALUE, BillingType.USAGE.toString());
+        assertEquals(LICENSE_VALUE, BillingType.LICENSE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/invoices/DocumentTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/invoices/DocumentTypeTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="DocumentTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.invoices;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DocumentTypeTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String INVOICE_VALUE = "invoice";
+    private static final String VOID_NOTE_VALUE = "void_note";
+    private static final String ADJUSTMENT_NOTE_VALUE = "adjustment_note";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String INVOICE_JSON = '"' + INVOICE_VALUE + '"';
+    private static final String VOID_NOTE_JSON = '"' + VOID_NOTE_VALUE + '"';
+    private static final String ADJUSTMENT_NOTE_JSON = '"' + ADJUSTMENT_NOTE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(DocumentType.NONE, jsonConverter.readValue(NONE_JSON, DocumentType.class));
+        assertEquals(DocumentType.INVOICE, jsonConverter.readValue(INVOICE_JSON, DocumentType.class));
+        assertEquals(DocumentType.VOID_NOTE, jsonConverter.readValue(VOID_NOTE_JSON, DocumentType.class));
+        assertEquals(DocumentType.ADJUSTMENT_NOTE, jsonConverter.readValue(ADJUSTMENT_NOTE_JSON, DocumentType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(DocumentType.NONE));
+        assertEquals(INVOICE_JSON, jsonConverter.writeValueAsString(DocumentType.INVOICE));
+        assertEquals(VOID_NOTE_JSON, jsonConverter.writeValueAsString(DocumentType.VOID_NOTE));
+        assertEquals(ADJUSTMENT_NOTE_JSON, jsonConverter.writeValueAsString(DocumentType.ADJUSTMENT_NOTE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, DocumentType.NONE.toString());
+        assertEquals(INVOICE_VALUE, DocumentType.INVOICE.toString());
+        assertEquals(VOID_NOTE_VALUE, DocumentType.VOID_NOTE.toString());
+        assertEquals(ADJUSTMENT_NOTE_VALUE, DocumentType.ADJUSTMENT_NOTE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/invoices/InvoiceSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/invoices/InvoiceSearchFieldTest.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="InvoiceSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.invoices;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InvoiceSearchFieldTest
+{
+    private static final String INVOICE_DATE_VALUE = "invoice_date";
+    private static final String INVOICE_DATE_JSON = '"' + INVOICE_DATE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(InvoiceSearchField.INVOICE_DATE, jsonConverter.readValue(INVOICE_DATE_JSON, InvoiceSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(INVOICE_DATE_JSON, jsonConverter.writeValueAsString(InvoiceSearchField.INVOICE_DATE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(INVOICE_DATE_VALUE, InvoiceSearchField.INVOICE_DATE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/licenses/LicenseGroupIdTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/licenses/LicenseGroupIdTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="LicenseGroupIdTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.licenses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LicenseGroupIdTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String GROUP1_VALUE = "group1";
+    private static final String GROUP2_VALUE = "group2";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String GROUP1_JSON = '"' + GROUP1_VALUE + '"';
+    private static final String GROUP2_JSON = '"' + GROUP2_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(LicenseGroupId.NONE, jsonConverter.readValue(NONE_JSON, LicenseGroupId.class));
+        assertEquals(LicenseGroupId.GROUP1, jsonConverter.readValue(GROUP1_JSON, LicenseGroupId.class));
+        assertEquals(LicenseGroupId.GROUP2, jsonConverter.readValue(GROUP2_JSON, LicenseGroupId.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(LicenseGroupId.NONE));
+        assertEquals(GROUP1_JSON, jsonConverter.writeValueAsString(LicenseGroupId.GROUP1));
+        assertEquals(GROUP2_JSON, jsonConverter.writeValueAsString(LicenseGroupId.GROUP2));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, LicenseGroupId.NONE.toString());
+        assertEquals(GROUP1_VALUE, LicenseGroupId.GROUP1.toString());
+        assertEquals(GROUP2_VALUE, LicenseGroupId.GROUP2.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/offers/BillingCycleTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/offers/BillingCycleTypeTest.java
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingCycleTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.offers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BillingCycleTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String MONTHLY_VALUE = "monthly";
+    private static final String ANNUAL_VALUE = "annual";
+    private static final String NONE_VALUE = "none";
+    private static final String ONE_TIME_VALUE = "one_time";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String MONTHLY_JSON = '"' + MONTHLY_VALUE + '"';
+    private static final String ANNUAL_JSON = '"' + ANNUAL_VALUE + '"';
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String ONE_TIME_JSON = '"' + ONE_TIME_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(BillingCycleType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.MONTHLY, jsonConverter.readValue(MONTHLY_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.ANNUAL, jsonConverter.readValue(ANNUAL_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.NONE, jsonConverter.readValue(NONE_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.ONE_TIME, jsonConverter.readValue(ONE_TIME_JSON, BillingCycleType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(BillingCycleType.UNKNOWN));
+        assertEquals(MONTHLY_JSON, jsonConverter.writeValueAsString(BillingCycleType.MONTHLY));
+        assertEquals(ANNUAL_JSON, jsonConverter.writeValueAsString(BillingCycleType.ANNUAL));
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(BillingCycleType.NONE));
+        assertEquals(ONE_TIME_JSON, jsonConverter.writeValueAsString(BillingCycleType.ONE_TIME));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, BillingCycleType.UNKNOWN.toString());
+        assertEquals(MONTHLY_VALUE, BillingCycleType.MONTHLY.toString());
+        assertEquals(ANNUAL_VALUE, BillingCycleType.ANNUAL.toString());
+        assertEquals(NONE_VALUE, BillingCycleType.NONE.toString());
+        assertEquals(ONE_TIME_VALUE, BillingCycleType.ONE_TIME.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="VettingStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.partners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VettingStatusTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String PENDING_VALUE = "pending";
+    private static final String AUTHORIZED_VALUE = "authorized";
+    private static final String REJECTED_VALUE = "rejected";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String PENDING_JSON = '"' + PENDING_VALUE + '"';
+    private static final String AUTHORIZED_JSON = '"' + AUTHORIZED_VALUE + '"';
+    private static final String REJECTED_JSON = '"' + REJECTED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(VettingStatus.NONE, jsonConverter.readValue(NONE_JSON, VettingStatus.class));
+        assertEquals(VettingStatus.PENDING, jsonConverter.readValue(PENDING_JSON, VettingStatus.class));
+        assertEquals(VettingStatus.AUTHORIZED, jsonConverter.readValue(AUTHORIZED_JSON, VettingStatus.class));
+        assertEquals(VettingStatus.REJECTED, jsonConverter.readValue(REJECTED_JSON, VettingStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(VettingStatus.NONE));
+        assertEquals(PENDING_JSON, jsonConverter.writeValueAsString(VettingStatus.PENDING));
+        assertEquals(AUTHORIZED_JSON, jsonConverter.writeValueAsString(VettingStatus.AUTHORIZED));
+        assertEquals(REJECTED_JSON, jsonConverter.writeValueAsString(VettingStatus.REJECTED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, VettingStatus.NONE.toString());
+        assertEquals(PENDING_VALUE, VettingStatus.PENDING.toString());
+        assertEquals(AUTHORIZED_VALUE, VettingStatus.AUTHORIZED.toString());
+        assertEquals(REJECTED_VALUE, VettingStatus.REJECTED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingSubStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingSubStatusTest.java
@@ -1,0 +1,83 @@
+// -----------------------------------------------------------------------
+// <copyright file="VettingSubStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.partners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VettingSubStatusTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String ENTRY_VALUE = "entry";
+    private static final String EMAIL_OWNERSHIP_VALUE = "email_ownership";
+    private static final String EMAIL_DOMAIN_VALUE = "email_domain";
+    private static final String EMPLOYMENT_VERIFICATION_VALUE = "employment_verification";
+    private static final String DECISION_VALUE = "decision";
+    private static final String OTHER_VALUE = "other";
+    private static final String BUSINESS_VERIFICATION_VALUE = "business_verification";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String ENTRY_JSON = '"' + ENTRY_VALUE + '"';
+    private static final String EMAIL_OWNERSHIP_JSON = '"' + EMAIL_OWNERSHIP_VALUE + '"';
+    private static final String EMAIL_DOMAIN_JSON = '"' + EMAIL_DOMAIN_VALUE + '"';
+    private static final String EMPLOYMENT_VERIFICATION_JSON = '"' + EMPLOYMENT_VERIFICATION_VALUE + '"';
+    private static final String DECISION_JSON = '"' + DECISION_VALUE + '"';
+    private static final String OTHER_JSON = '"' + OTHER_VALUE + '"';
+    private static final String BUSINESS_VERIFICATION_JSON = '"' + BUSINESS_VERIFICATION_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(VettingSubStatus.NONE, jsonConverter.readValue(NONE_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.ENTRY, jsonConverter.readValue(ENTRY_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.EMAIL_OWNERSHIP, jsonConverter.readValue(EMAIL_OWNERSHIP_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.EMAIL_DOMAIN, jsonConverter.readValue(EMAIL_DOMAIN_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.EMPLOYMENT_VERIFICATION, jsonConverter.readValue(EMPLOYMENT_VERIFICATION_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.DECISION, jsonConverter.readValue(DECISION_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.OTHER, jsonConverter.readValue(OTHER_JSON, VettingSubStatus.class));
+        assertEquals(VettingSubStatus.BUSINESS_VERIFICATION, jsonConverter.readValue(BUSINESS_VERIFICATION_JSON, VettingSubStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(VettingSubStatus.NONE));
+        assertEquals(ENTRY_JSON, jsonConverter.writeValueAsString(VettingSubStatus.ENTRY));
+        assertEquals(EMAIL_OWNERSHIP_JSON, jsonConverter.writeValueAsString(VettingSubStatus.EMAIL_OWNERSHIP));
+        assertEquals(EMAIL_DOMAIN_JSON, jsonConverter.writeValueAsString(VettingSubStatus.EMAIL_DOMAIN));
+        assertEquals(EMPLOYMENT_VERIFICATION_JSON, jsonConverter.writeValueAsString(VettingSubStatus.EMPLOYMENT_VERIFICATION));
+        assertEquals(DECISION_JSON, jsonConverter.writeValueAsString(VettingSubStatus.DECISION));
+        assertEquals(OTHER_JSON, jsonConverter.writeValueAsString(VettingSubStatus.OTHER));
+        assertEquals(BUSINESS_VERIFICATION_JSON, jsonConverter.writeValueAsString(VettingSubStatus.BUSINESS_VERIFICATION));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, VettingSubStatus.NONE.toString());
+        assertEquals(ENTRY_VALUE, VettingSubStatus.ENTRY.toString());
+        assertEquals(EMAIL_OWNERSHIP_VALUE, VettingSubStatus.EMAIL_OWNERSHIP.toString());
+        assertEquals(EMAIL_DOMAIN_VALUE, VettingSubStatus.EMAIL_DOMAIN.toString());
+        assertEquals(EMPLOYMENT_VERIFICATION_VALUE, VettingSubStatus.EMPLOYMENT_VERIFICATION.toString());
+        assertEquals(DECISION_VALUE, VettingSubStatus.DECISION.toString());
+        assertEquals(OTHER_VALUE, VettingSubStatus.OTHER.toString());
+        assertEquals(BUSINESS_VERIFICATION_VALUE, VettingSubStatus.BUSINESS_VERIFICATION.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingVersionTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/partners/VettingVersionTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="VettingVersionTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.partners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VettingVersionTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String CURRENT_VALUE = "current";
+    private static final String LAST_FINALIZED_VALUE = "last_finalized";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String CURRENT_JSON = '"' + CURRENT_VALUE + '"';
+    private static final String LAST_FINALIZED_JSON = '"' + LAST_FINALIZED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(VettingVersion.NONE, jsonConverter.readValue(NONE_JSON, VettingVersion.class));
+        assertEquals(VettingVersion.CURRENT, jsonConverter.readValue(CURRENT_JSON, VettingVersion.class));
+        assertEquals(VettingVersion.LAST_FINALIZED, jsonConverter.readValue(LAST_FINALIZED_JSON, VettingVersion.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(VettingVersion.NONE));
+        assertEquals(CURRENT_JSON, jsonConverter.writeValueAsString(VettingVersion.CURRENT));
+        assertEquals(LAST_FINALIZED_JSON, jsonConverter.writeValueAsString(VettingVersion.LAST_FINALIZED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, VettingVersion.NONE.toString());
+        assertEquals(CURRENT_VALUE, VettingVersion.CURRENT.toString());
+        assertEquals(LAST_FINALIZED_VALUE, VettingVersion.LAST_FINALIZED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/products/BillingCycleTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/products/BillingCycleTypeTest.java
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="BillingCycleTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.products;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BillingCycleTypeTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String MONTHLY_VALUE = "monthly";
+    private static final String ANNUAL_VALUE = "annual";
+    private static final String NONE_VALUE = "none";
+    private static final String ONE_TIME_VALUE = "one_time";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String MONTHLY_JSON = '"' + MONTHLY_VALUE + '"';
+    private static final String ANNUAL_JSON = '"' + ANNUAL_VALUE + '"';
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String ONE_TIME_JSON = '"' + ONE_TIME_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(BillingCycleType.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.MONTHLY, jsonConverter.readValue(MONTHLY_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.ANNUAL, jsonConverter.readValue(ANNUAL_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.NONE, jsonConverter.readValue(NONE_JSON, BillingCycleType.class));
+        assertEquals(BillingCycleType.ONE_TIME, jsonConverter.readValue(ONE_TIME_JSON, BillingCycleType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(BillingCycleType.UNKNOWN));
+        assertEquals(MONTHLY_JSON, jsonConverter.writeValueAsString(BillingCycleType.MONTHLY));
+        assertEquals(ANNUAL_JSON, jsonConverter.writeValueAsString(BillingCycleType.ANNUAL));
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(BillingCycleType.NONE));
+        assertEquals(ONE_TIME_JSON, jsonConverter.writeValueAsString(BillingCycleType.ONE_TIME));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, BillingCycleType.UNKNOWN.toString());
+        assertEquals(MONTHLY_VALUE, BillingCycleType.MONTHLY.toString());
+        assertEquals(ANNUAL_VALUE, BillingCycleType.ANNUAL.toString());
+        assertEquals(NONE_VALUE, BillingCycleType.NONE.toString());
+        assertEquals(ONE_TIME_VALUE, BillingCycleType.ONE_TIME.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/query/SeekOperationTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/query/SeekOperationTest.java
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------
+// <copyright file="SeekOperationTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SeekOperationTest
+{
+    private static final String NEXT_VALUE = "Next";
+    private static final String PREVIOUS_VALUE = "Previous";
+    private static final String FIRST_VALUE = "First";
+    private static final String LAST_VALUE = "Last";
+    private static final String PAGE_INDEX_VALUE = "PageIndex";
+    private static final String NEXT_JSON = '"' + NEXT_VALUE + '"';
+    private static final String PREVIOUS_JSON = '"' + PREVIOUS_VALUE + '"';
+    private static final String FIRST_JSON = '"' + FIRST_VALUE + '"';
+    private static final String LAST_JSON = '"' + LAST_VALUE + '"';
+    private static final String PAGE_INDEX_JSON = '"' + PAGE_INDEX_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(SeekOperation.NEXT, jsonConverter.readValue(NEXT_JSON, SeekOperation.class));
+        assertEquals(SeekOperation.PREVIOUS, jsonConverter.readValue(PREVIOUS_JSON, SeekOperation.class));
+        assertEquals(SeekOperation.FIRST, jsonConverter.readValue(FIRST_JSON, SeekOperation.class));
+        assertEquals(SeekOperation.LAST, jsonConverter.readValue(LAST_JSON, SeekOperation.class));
+        assertEquals(SeekOperation.PAGE_INDEX, jsonConverter.readValue(PAGE_INDEX_JSON, SeekOperation.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NEXT_JSON, jsonConverter.writeValueAsString(SeekOperation.NEXT));
+        assertEquals(PREVIOUS_JSON, jsonConverter.writeValueAsString(SeekOperation.PREVIOUS));
+        assertEquals(FIRST_JSON, jsonConverter.writeValueAsString(SeekOperation.FIRST));
+        assertEquals(LAST_JSON, jsonConverter.writeValueAsString(SeekOperation.LAST));
+        assertEquals(PAGE_INDEX_JSON, jsonConverter.writeValueAsString(SeekOperation.PAGE_INDEX));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NEXT_VALUE, SeekOperation.NEXT.toString());
+        assertEquals(PREVIOUS_VALUE, SeekOperation.PREVIOUS.toString());
+        assertEquals(FIRST_VALUE, SeekOperation.FIRST.toString());
+        assertEquals(LAST_VALUE, SeekOperation.LAST.toString());
+        assertEquals(PAGE_INDEX_VALUE, SeekOperation.PAGE_INDEX.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/query/filters/FieldFilterOperationTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/query/filters/FieldFilterOperationTest.java
@@ -1,0 +1,98 @@
+// -----------------------------------------------------------------------
+// <copyright file="FieldFilterOperationTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.query.filters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FieldFilterOperationTest
+{
+    private static final String EQUALS_VALUE = "Equals";
+    private static final String NOT_EQUALS_VALUE = "NotEquals";
+    private static final String GREATER_THAN_VALUE = "GreaterThan";
+    private static final String GREATER_THAN_OR_EQUALS_VALUE = "GreaterThanOrEquals";
+    private static final String LESS_THAN_VALUE = "LessThan";
+    private static final String LESS_THAN_OR_EQUALS_VALUE = "LessThanOrEquals";
+    private static final String SUBSTRING_VALUE = "Substring";
+    private static final String AND_VALUE = "And";
+    private static final String OR_VALUE = "Or";
+    private static final String STARTS_WITH_VALUE = "StartsWith";
+    private static final String NOT_STARTS_WITH_VALUE = "NotStartsWith";
+    private static final String EQUALS_JSON = '"' + EQUALS_VALUE + '"';
+    private static final String NOT_EQUALS_JSON = '"' + NOT_EQUALS_VALUE + '"';
+    private static final String GREATER_THAN_JSON = '"' + GREATER_THAN_VALUE + '"';
+    private static final String GREATER_THAN_OR_EQUALS_JSON = '"' + GREATER_THAN_OR_EQUALS_VALUE + '"';
+    private static final String LESS_THAN_JSON = '"' + LESS_THAN_VALUE + '"';
+    private static final String LESS_THAN_OR_EQUALS_JSON = '"' + LESS_THAN_OR_EQUALS_VALUE + '"';
+    private static final String SUBSTRING_JSON = '"' + SUBSTRING_VALUE + '"';
+    private static final String AND_JSON = '"' + AND_VALUE + '"';
+    private static final String OR_JSON = '"' + OR_VALUE + '"';
+    private static final String STARTS_WITH_JSON = '"' + STARTS_WITH_VALUE + '"';
+    private static final String NOT_STARTS_WITH_JSON = '"' + NOT_STARTS_WITH_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(FieldFilterOperation.EQUALS, jsonConverter.readValue(EQUALS_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.NOT_EQUALS, jsonConverter.readValue(NOT_EQUALS_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.GREATER_THAN, jsonConverter.readValue(GREATER_THAN_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.GREATER_THAN_OR_EQUALS, jsonConverter.readValue(GREATER_THAN_OR_EQUALS_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.LESS_THAN, jsonConverter.readValue(LESS_THAN_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.LESS_THAN_OR_EQUALS, jsonConverter.readValue(LESS_THAN_OR_EQUALS_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.SUBSTRING, jsonConverter.readValue(SUBSTRING_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.AND, jsonConverter.readValue(AND_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.OR, jsonConverter.readValue(OR_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.STARTS_WITH, jsonConverter.readValue(STARTS_WITH_JSON, FieldFilterOperation.class));
+        assertEquals(FieldFilterOperation.NOT_STARTS_WITH, jsonConverter.readValue(NOT_STARTS_WITH_JSON, FieldFilterOperation.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(EQUALS_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.EQUALS));
+        assertEquals(NOT_EQUALS_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.NOT_EQUALS));
+        assertEquals(GREATER_THAN_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.GREATER_THAN));
+        assertEquals(GREATER_THAN_OR_EQUALS_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.GREATER_THAN_OR_EQUALS));
+        assertEquals(LESS_THAN_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.LESS_THAN));
+        assertEquals(LESS_THAN_OR_EQUALS_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.LESS_THAN_OR_EQUALS));
+        assertEquals(SUBSTRING_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.SUBSTRING));
+        assertEquals(AND_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.AND));
+        assertEquals(OR_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.OR));
+        assertEquals(STARTS_WITH_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.STARTS_WITH));
+        assertEquals(NOT_STARTS_WITH_JSON, jsonConverter.writeValueAsString(FieldFilterOperation.NOT_STARTS_WITH));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(EQUALS_VALUE, FieldFilterOperation.EQUALS.toString());
+        assertEquals(NOT_EQUALS_VALUE, FieldFilterOperation.NOT_EQUALS.toString());
+        assertEquals(GREATER_THAN_VALUE, FieldFilterOperation.GREATER_THAN.toString());
+        assertEquals(GREATER_THAN_OR_EQUALS_VALUE, FieldFilterOperation.GREATER_THAN_OR_EQUALS.toString());
+        assertEquals(LESS_THAN_VALUE, FieldFilterOperation.LESS_THAN.toString());
+        assertEquals(LESS_THAN_OR_EQUALS_VALUE, FieldFilterOperation.LESS_THAN_OR_EQUALS.toString());
+        assertEquals(SUBSTRING_VALUE, FieldFilterOperation.SUBSTRING.toString());
+        assertEquals(AND_VALUE, FieldFilterOperation.AND.toString());
+        assertEquals(OR_VALUE, FieldFilterOperation.OR.toString());
+        assertEquals(STARTS_WITH_VALUE, FieldFilterOperation.STARTS_WITH.toString());
+        assertEquals(NOT_STARTS_WITH_VALUE, FieldFilterOperation.NOT_STARTS_WITH.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/query/filters/FieldTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/query/filters/FieldTypeTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="FieldTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.query.filters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FieldTypeTest
+{
+    private static final String STRING_VALUE = "String";
+    private static final String INTEGER_VALUE = "Integer";
+    private static final String ENUM_VALUE = "Enum";
+    private static final String DATE_TIME_OFFSET_VALUE = "DateTimeOffset";
+    private static final String STRING_JSON = '"' + STRING_VALUE + '"';
+    private static final String INTEGER_JSON = '"' + INTEGER_VALUE + '"';
+    private static final String ENUM_JSON = '"' + ENUM_VALUE + '"';
+    private static final String DATE_TIME_OFFSET_JSON = '"' + DATE_TIME_OFFSET_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(FieldType.STRING, jsonConverter.readValue(STRING_JSON, FieldType.class));
+        assertEquals(FieldType.INTEGER, jsonConverter.readValue(INTEGER_JSON, FieldType.class));
+        assertEquals(FieldType.ENUM, jsonConverter.readValue(ENUM_JSON, FieldType.class));
+        assertEquals(FieldType.DATE_TIME_OFFSET, jsonConverter.readValue(DATE_TIME_OFFSET_JSON, FieldType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(STRING_JSON, jsonConverter.writeValueAsString(FieldType.STRING));
+        assertEquals(INTEGER_JSON, jsonConverter.writeValueAsString(FieldType.INTEGER));
+        assertEquals(ENUM_JSON, jsonConverter.writeValueAsString(FieldType.ENUM));
+        assertEquals(DATE_TIME_OFFSET_JSON, jsonConverter.writeValueAsString(FieldType.DATE_TIME_OFFSET));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(STRING_VALUE, FieldType.STRING.toString());
+        assertEquals(INTEGER_VALUE, FieldType.INTEGER.toString());
+        assertEquals(ENUM_VALUE, FieldType.ENUM.toString());
+        assertEquals(DATE_TIME_OFFSET_VALUE, FieldType.DATE_TIME_OFFSET.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/query/sort/SortDirectionTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/query/sort/SortDirectionTest.java
@@ -1,0 +1,47 @@
+package com.microsoft.store.partnercenter.models.query.sort;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SortDirectionTest
+{
+    private static final String ASCENDING_VALUE = "ascending";
+    private static final String DESCENDING_VALUE = "descending";
+    private static final String ASCENDING_JSON = '"' + ASCENDING_VALUE + '"';
+    private static final String DESCENDING_JSON = '"' + DESCENDING_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(SortDirection.ASCENDING, jsonConverter.readValue(ASCENDING_JSON, SortDirection.class));
+        assertEquals(SortDirection.DESCENDING, jsonConverter.readValue(DESCENDING_JSON, SortDirection.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(ASCENDING_JSON, jsonConverter.writeValueAsString(SortDirection.ASCENDING));
+        assertEquals(DESCENDING_JSON, jsonConverter.writeValueAsString(SortDirection.DESCENDING));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(ASCENDING_VALUE, SortDirection.ASCENDING.toString());
+        assertEquals(DESCENDING_VALUE, SortDirection.DESCENDING.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipSearchFieldTest.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="PartnerRelationshipSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.relationships;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PartnerRelationshipSearchFieldTest
+{
+    private static final String NAME_VALUE = "name";
+    private static final String NAME_JSON = '"' + NAME_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(PartnerRelationshipSearchField.NAME, jsonConverter.readValue(NAME_JSON, PartnerRelationshipSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NAME_JSON, jsonConverter.writeValueAsString(PartnerRelationshipSearchField.NAME));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NAME_VALUE, PartnerRelationshipSearchField.NAME.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/relationships/PartnerRelationshipTypeTest.java
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="PartnerRelationshipTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.relationships;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PartnerRelationshipTypeTest
+{
+    private static final String IS_INDIRECT_RESELLER_OF_VALUE = "is_indirect_reseller_of";
+    private static final String IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_VALUE = "is_indirect_cloud_solution_provider_of";
+    private static final String IS_INDIRECT_RESELLER_OF_JSON = '"' + IS_INDIRECT_RESELLER_OF_VALUE + '"';
+    private static final String IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_JSON = '"' + IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(PartnerRelationshipType.IS_INDIRECT_RESELLER_OF, jsonConverter.readValue(IS_INDIRECT_RESELLER_OF_JSON, PartnerRelationshipType.class));
+        assertEquals(PartnerRelationshipType.IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF, jsonConverter.readValue(IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_JSON, PartnerRelationshipType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(IS_INDIRECT_RESELLER_OF_JSON, jsonConverter.writeValueAsString(PartnerRelationshipType.IS_INDIRECT_RESELLER_OF));
+        assertEquals(IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_JSON, jsonConverter.writeValueAsString(PartnerRelationshipType.IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(IS_INDIRECT_RESELLER_OF_VALUE, PartnerRelationshipType.IS_INDIRECT_RESELLER_OF.toString());
+        assertEquals(IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF_VALUE, PartnerRelationshipType.IS_INDIRECT_CLOUD_SOLUTION_PROVIDER_OF.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/servicecosts/ServiceCostsBillingPeriodTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/servicecosts/ServiceCostsBillingPeriodTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceCostsBillingPeriodTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.servicecosts;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceCostsBillingPeriodTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String MOST_RECENT_VALUE = "most_recent";
+    private static final String CURRENT_VALUE = "current";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String MOST_RECENT_JSON = '"' + MOST_RECENT_VALUE + '"';
+    private static final String CURRENT_JSON = '"' + CURRENT_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceCostsBillingPeriod.NONE, jsonConverter.readValue(NONE_JSON, ServiceCostsBillingPeriod.class));
+        assertEquals(ServiceCostsBillingPeriod.MOST_RECENT, jsonConverter.readValue(MOST_RECENT_JSON, ServiceCostsBillingPeriod.class));
+        assertEquals(ServiceCostsBillingPeriod.CURRENT, jsonConverter.readValue(CURRENT_JSON, ServiceCostsBillingPeriod.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(ServiceCostsBillingPeriod.NONE));
+        assertEquals(MOST_RECENT_JSON, jsonConverter.writeValueAsString(ServiceCostsBillingPeriod.MOST_RECENT));
+        assertEquals(CURRENT_JSON, jsonConverter.writeValueAsString(ServiceCostsBillingPeriod.CURRENT));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, ServiceCostsBillingPeriod.NONE.toString());
+        assertEquals(MOST_RECENT_VALUE, ServiceCostsBillingPeriod.MOST_RECENT.toString());
+        assertEquals(CURRENT_VALUE, ServiceCostsBillingPeriod.CURRENT.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/MessageTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/MessageTypeTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="MessageTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.serviceincidents;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MessageTypeTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String INCIDENT_VALUE = "incident";
+    private static final String MESSAGE_CENTER_VALUE = "message_center";
+    private static final String ALL_VALUE = "all";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String INCIDENT_JSON = '"' + INCIDENT_VALUE + '"';
+    private static final String MESSAGE_CENTER_JSON = '"' + MESSAGE_CENTER_VALUE + '"';
+    private static final String ALL_JSON = '"' + ALL_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(MessageType.NONE, jsonConverter.readValue(NONE_JSON, MessageType.class));
+        assertEquals(MessageType.INCIDENT, jsonConverter.readValue(INCIDENT_JSON, MessageType.class));
+        assertEquals(MessageType.MESSAGE_CENTER, jsonConverter.readValue(MESSAGE_CENTER_JSON, MessageType.class));
+        assertEquals(MessageType.ALL, jsonConverter.readValue(ALL_JSON, MessageType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(MessageType.NONE));
+        assertEquals(INCIDENT_JSON, jsonConverter.writeValueAsString(MessageType.INCIDENT));
+        assertEquals(MESSAGE_CENTER_JSON, jsonConverter.writeValueAsString(MessageType.MESSAGE_CENTER));
+        assertEquals(ALL_JSON, jsonConverter.writeValueAsString(MessageType.ALL));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, MessageType.NONE.toString());
+        assertEquals(INCIDENT_VALUE, MessageType.INCIDENT.toString());
+        assertEquals(MESSAGE_CENTER_VALUE, MessageType.MESSAGE_CENTER.toString());
+        assertEquals(ALL_VALUE, MessageType.ALL.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentSearchFieldTest.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceIncidentSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.serviceincidents;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceIncidentSearchFieldTest
+{
+    private static final String RESOLVED_VALUE = "Resolved";
+    private static final String RESOLVED_JSON = '"' + RESOLVED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceIncidentSearchField.RESOLVED, jsonConverter.readValue(RESOLVED_JSON, ServiceIncidentSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(RESOLVED_JSON, jsonConverter.writeValueAsString(ServiceIncidentSearchField.RESOLVED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(RESOLVED_VALUE, ServiceIncidentSearchField.RESOLVED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/serviceincidents/ServiceIncidentStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceIncidentStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.serviceincidents;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceIncidentStatusTest
+{
+    private static final String NORMAL_VALUE = "normal";
+    private static final String INFORMATION_VALUE = "information";
+    private static final String WARNING_VALUE = "warning";
+    private static final String CRITICAL_VALUE = "critical";
+    private static final String NORMAL_JSON = '"' + NORMAL_VALUE + '"';
+    private static final String INFORMATION_JSON = '"' + INFORMATION_VALUE + '"';
+    private static final String WARNING_JSON = '"' + WARNING_VALUE + '"';
+    private static final String CRITICAL_JSON = '"' + CRITICAL_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceIncidentStatus.NORMAL, jsonConverter.readValue(NORMAL_JSON, ServiceIncidentStatus.class));
+        assertEquals(ServiceIncidentStatus.INFORMATION, jsonConverter.readValue(INFORMATION_JSON, ServiceIncidentStatus.class));
+        assertEquals(ServiceIncidentStatus.WARNING, jsonConverter.readValue(WARNING_JSON, ServiceIncidentStatus.class));
+        assertEquals(ServiceIncidentStatus.CRITICAL, jsonConverter.readValue(CRITICAL_JSON, ServiceIncidentStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NORMAL_JSON, jsonConverter.writeValueAsString(ServiceIncidentStatus.NORMAL));
+        assertEquals(INFORMATION_JSON, jsonConverter.writeValueAsString(ServiceIncidentStatus.INFORMATION));
+        assertEquals(WARNING_JSON, jsonConverter.writeValueAsString(ServiceIncidentStatus.WARNING));
+        assertEquals(CRITICAL_JSON, jsonConverter.writeValueAsString(ServiceIncidentStatus.CRITICAL));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NORMAL_VALUE, ServiceIncidentStatus.NORMAL.toString());
+        assertEquals(INFORMATION_VALUE, ServiceIncidentStatus.INFORMATION.toString());
+        assertEquals(WARNING_VALUE, ServiceIncidentStatus.WARNING.toString());
+        assertEquals(CRITICAL_VALUE, ServiceIncidentStatus.CRITICAL.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSearchFieldTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSearchFieldTest.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceRequestSearchFieldTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.servicerequests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceRequestSearchFieldTest
+{
+    private static final String STATUS_VALUE = "Status";
+    private static final String STATUS_JSON = '"' + STATUS_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceRequestSearchField.STATUS, jsonConverter.readValue(STATUS_JSON, ServiceRequestSearchField.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(STATUS_JSON, jsonConverter.writeValueAsString(ServiceRequestSearchField.STATUS));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(STATUS_VALUE, ServiceRequestSearchField.STATUS.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSeverityTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestSeverityTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceRequestSeverityTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.servicerequests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceRequestSeverityTest
+{
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String CRITICAL_VALUE = "critical";
+    private static final String MODERATE_VALUE = "moderate";
+    private static final String MINIMAL_VALUE = "minimal";
+    private static final String UNKNOWN_JSON = '"' + UNKNOWN_VALUE + '"';
+    private static final String CRITICAL_JSON = '"' + CRITICAL_VALUE + '"';
+    private static final String MODERATE_JSON = '"' + MODERATE_VALUE + '"';
+    private static final String MINIMAL_JSON = '"' + MINIMAL_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceRequestSeverity.UNKNOWN, jsonConverter.readValue(UNKNOWN_JSON, ServiceRequestSeverity.class));
+        assertEquals(ServiceRequestSeverity.CRITICAL, jsonConverter.readValue(CRITICAL_JSON, ServiceRequestSeverity.class));
+        assertEquals(ServiceRequestSeverity.MODERATE, jsonConverter.readValue(MODERATE_JSON, ServiceRequestSeverity.class));
+        assertEquals(ServiceRequestSeverity.MINIMAL, jsonConverter.readValue(MINIMAL_JSON, ServiceRequestSeverity.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(UNKNOWN_JSON, jsonConverter.writeValueAsString(ServiceRequestSeverity.UNKNOWN));
+        assertEquals(CRITICAL_JSON, jsonConverter.writeValueAsString(ServiceRequestSeverity.CRITICAL));
+        assertEquals(MODERATE_JSON, jsonConverter.writeValueAsString(ServiceRequestSeverity.MODERATE));
+        assertEquals(MINIMAL_JSON, jsonConverter.writeValueAsString(ServiceRequestSeverity.MINIMAL));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(UNKNOWN_VALUE, ServiceRequestSeverity.UNKNOWN.toString());
+        assertEquals(CRITICAL_VALUE, ServiceRequestSeverity.CRITICAL.toString());
+        assertEquals(MODERATE_VALUE, ServiceRequestSeverity.MODERATE.toString());
+        assertEquals(MINIMAL_VALUE, ServiceRequestSeverity.MINIMAL.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/servicerequests/ServiceRequestStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ServiceRequestStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.servicerequests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceRequestStatusTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String OPEN_VALUE = "open";
+    private static final String CLOSED_VALUE = "closed";
+    private static final String ATTENTION_NEEDED_VALUE = "attention_needed";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String OPEN_JSON = '"' + OPEN_VALUE + '"';
+    private static final String CLOSED_JSON = '"' + CLOSED_VALUE + '"';
+    private static final String ATTENTION_NEEDED_JSON = '"' + ATTENTION_NEEDED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ServiceRequestStatus.NONE, jsonConverter.readValue(NONE_JSON, ServiceRequestStatus.class));
+        assertEquals(ServiceRequestStatus.OPEN, jsonConverter.readValue(OPEN_JSON, ServiceRequestStatus.class));
+        assertEquals(ServiceRequestStatus.CLOSED, jsonConverter.readValue(CLOSED_JSON, ServiceRequestStatus.class));
+        assertEquals(ServiceRequestStatus.ATTENTION_NEEDED, jsonConverter.readValue(ATTENTION_NEEDED_JSON, ServiceRequestStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(ServiceRequestStatus.NONE));
+        assertEquals(OPEN_JSON, jsonConverter.writeValueAsString(ServiceRequestStatus.OPEN));
+        assertEquals(CLOSED_JSON, jsonConverter.writeValueAsString(ServiceRequestStatus.CLOSED));
+        assertEquals(ATTENTION_NEEDED_JSON, jsonConverter.writeValueAsString(ServiceRequestStatus.ATTENTION_NEEDED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, ServiceRequestStatus.NONE.toString());
+        assertEquals(OPEN_VALUE, ServiceRequestStatus.OPEN.toString());
+        assertEquals(CLOSED_VALUE, ServiceRequestStatus.CLOSED.toString());
+        assertEquals(ATTENTION_NEEDED_VALUE, ServiceRequestStatus.ATTENTION_NEEDED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/ConversionErrorCodeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/ConversionErrorCodeTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ConversionErrorCodeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConversionErrorCodeTest
+{
+    private static final String OTHER_VALUE = "other";
+    private static final String CONVERSIONS_NOT_FOUND_VALUE = "conversions_not_found";
+    private static final String PENDING_VALUE = "pending";
+    private static final String FAILED_VALUE = "failed";
+    private static final String OTHER_JSON = '"' + OTHER_VALUE + '"';
+    private static final String CONVERSIONS_NOT_FOUND_JSON = '"' + CONVERSIONS_NOT_FOUND_VALUE + '"';
+    private static final String PENDING_JSON = '"' + PENDING_VALUE + '"';
+    private static final String FAILED_JSON = '"' + FAILED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ConversionErrorCode.OTHER, jsonConverter.readValue(OTHER_JSON, ConversionErrorCode.class));
+        assertEquals(ConversionErrorCode.CONVERSIONS_NOT_FOUND, jsonConverter.readValue(CONVERSIONS_NOT_FOUND_JSON, ConversionErrorCode.class));
+        assertEquals(ConversionErrorCode.PENDING, jsonConverter.readValue(PENDING_JSON, ConversionErrorCode.class));
+        assertEquals(ConversionErrorCode.FAILED, jsonConverter.readValue(FAILED_JSON, ConversionErrorCode.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(OTHER_JSON, jsonConverter.writeValueAsString(ConversionErrorCode.OTHER));
+        assertEquals(CONVERSIONS_NOT_FOUND_JSON, jsonConverter.writeValueAsString(ConversionErrorCode.CONVERSIONS_NOT_FOUND));
+        assertEquals(PENDING_JSON, jsonConverter.writeValueAsString(ConversionErrorCode.PENDING));
+        assertEquals(FAILED_JSON, jsonConverter.writeValueAsString(ConversionErrorCode.FAILED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(OTHER_VALUE, ConversionErrorCode.OTHER.toString());
+        assertEquals(CONVERSIONS_NOT_FOUND_VALUE, ConversionErrorCode.CONVERSIONS_NOT_FOUND.toString());
+        assertEquals(PENDING_VALUE, ConversionErrorCode.PENDING.toString());
+        assertEquals(FAILED_VALUE, ConversionErrorCode.FAILED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/ProvisioningStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/ProvisioningStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="ProvisioningStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProvisioningStatusTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String SUCCESS_VALUE = "success";
+    private static final String PENDING_VALUE = "pending";
+    private static final String FAILED_VALUE = "failed";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String SUCCESS_JSON = '"' + SUCCESS_VALUE + '"';
+    private static final String PENDING_JSON = '"' + PENDING_VALUE + '"';
+    private static final String FAILED_JSON = '"' + FAILED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(ProvisioningStatus.NONE, jsonConverter.readValue(NONE_JSON, ProvisioningStatus.class));
+        assertEquals(ProvisioningStatus.SUCCESS, jsonConverter.readValue(SUCCESS_JSON, ProvisioningStatus.class));
+        assertEquals(ProvisioningStatus.PENDING, jsonConverter.readValue(PENDING_JSON, ProvisioningStatus.class));
+        assertEquals(ProvisioningStatus.FAILED, jsonConverter.readValue(FAILED_JSON, ProvisioningStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(ProvisioningStatus.NONE));
+        assertEquals(SUCCESS_JSON, jsonConverter.writeValueAsString(ProvisioningStatus.SUCCESS));
+        assertEquals(PENDING_JSON, jsonConverter.writeValueAsString(ProvisioningStatus.PENDING));
+        assertEquals(FAILED_JSON, jsonConverter.writeValueAsString(ProvisioningStatus.FAILED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, ProvisioningStatus.NONE.toString());
+        assertEquals(SUCCESS_VALUE, ProvisioningStatus.SUCCESS.toString());
+        assertEquals(PENDING_VALUE, ProvisioningStatus.PENDING.toString());
+        assertEquals(FAILED_VALUE, ProvisioningStatus.FAILED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/SubscriptionStatusTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/SubscriptionStatusTest.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="SubscriptionStatusTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SubscriptionStatusTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String ACTIVE_VALUE = "active";
+    private static final String SUSPENDED_VALUE = "suspended";
+    private static final String DELETED_VALUE = "deleted";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String ACTIVE_JSON = '"' + ACTIVE_VALUE + '"';
+    private static final String SUSPENDED_JSON = '"' + SUSPENDED_VALUE + '"';
+    private static final String DELETED_JSON = '"' + DELETED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(SubscriptionStatus.NONE, jsonConverter.readValue(NONE_JSON, SubscriptionStatus.class));
+        assertEquals(SubscriptionStatus.ACTIVE, jsonConverter.readValue(ACTIVE_JSON, SubscriptionStatus.class));
+        assertEquals(SubscriptionStatus.SUSPENDED, jsonConverter.readValue(SUSPENDED_JSON, SubscriptionStatus.class));
+        assertEquals(SubscriptionStatus.DELETED, jsonConverter.readValue(DELETED_JSON, SubscriptionStatus.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(SubscriptionStatus.NONE));
+        assertEquals(ACTIVE_JSON, jsonConverter.writeValueAsString(SubscriptionStatus.ACTIVE));
+        assertEquals(SUSPENDED_JSON, jsonConverter.writeValueAsString(SubscriptionStatus.SUSPENDED));
+        assertEquals(DELETED_JSON, jsonConverter.writeValueAsString(SubscriptionStatus.DELETED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, SubscriptionStatus.NONE.toString());
+        assertEquals(ACTIVE_VALUE, SubscriptionStatus.ACTIVE.toString());
+        assertEquals(SUSPENDED_VALUE, SubscriptionStatus.SUSPENDED.toString());
+        assertEquals(DELETED_VALUE, SubscriptionStatus.DELETED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeErrorCodeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeErrorCodeTest.java
@@ -1,0 +1,93 @@
+// -----------------------------------------------------------------------
+// <copyright file="UpgradeErrorCodeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UpgradeErrorCodeTest
+{
+    private static final String OTHER_VALUE = "Other";
+    private static final String DELEGATED_ADMIN_PERMISSIONS_DISABLED_VALUE = "DelegatedAdminPermissionsDisabled";
+    private static final String SUBSCRIPTION_STATUS_NOT_ACTIVE_VALUE = "SubscriptionStatusNotActive";
+    private static final String CONFLICTING_SERVICE_TYPES_VALUE = "ConflictingServiceTypes";
+    private static final String CONCURRENCY_CONFLICTS_VALUE = "ConcurrencyConflicts";
+    private static final String USER_CONTEXT_REQUIRED_VALUE = "UserContextRequired";
+    private static final String SUBSCRIPTION_ADD_ONS_PRESENT_VALUE = "SubscriptionAddOnsPresent";
+    private static final String SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_VALUE = "SubscriptionDoesNotHaveAnyUpgradePaths";
+    private static final String SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_VALUE = "SubscriptionTargetOfferNotFound";
+    private static final String SUBSCRIPTION_NOT_PROVISIONED_VALUE = "SubscriptionNotProvisioned";
+    private static final String OTHER_JSON = '"' + OTHER_VALUE + '"';
+    private static final String DELEGATED_ADMIN_PERMISSIONS_DISABLED_JSON = '"' + DELEGATED_ADMIN_PERMISSIONS_DISABLED_VALUE + '"';
+    private static final String SUBSCRIPTION_STATUS_NOT_ACTIVE_JSON = '"' + SUBSCRIPTION_STATUS_NOT_ACTIVE_VALUE + '"';
+    private static final String CONFLICTING_SERVICE_TYPES_JSON = '"' + CONFLICTING_SERVICE_TYPES_VALUE + '"';
+    private static final String CONCURRENCY_CONFLICTS_JSON = '"' + CONCURRENCY_CONFLICTS_VALUE + '"';
+    private static final String USER_CONTEXT_REQUIRED_JSON = '"' + USER_CONTEXT_REQUIRED_VALUE + '"';
+    private static final String SUBSCRIPTION_ADD_ONS_PRESENT_JSON = '"' + SUBSCRIPTION_ADD_ONS_PRESENT_VALUE + '"';
+    private static final String SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_JSON = '"' + SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_VALUE + '"';
+    private static final String SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_JSON = '"' + SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_VALUE + '"';
+    private static final String SUBSCRIPTION_NOT_PROVISIONED_JSON = '"' + SUBSCRIPTION_NOT_PROVISIONED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(UpgradeErrorCode.OTHER, jsonConverter.readValue(OTHER_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.DELEGATED_ADMIN_PERMISSIONS_DISABLED, jsonConverter.readValue(DELEGATED_ADMIN_PERMISSIONS_DISABLED_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.SUBSCRIPTION_STATUS_NOT_ACTIVE, jsonConverter.readValue(SUBSCRIPTION_STATUS_NOT_ACTIVE_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.CONFLICTING_SERVICE_TYPES, jsonConverter.readValue(CONFLICTING_SERVICE_TYPES_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.CONCURRENCY_CONFLICTS, jsonConverter.readValue(CONCURRENCY_CONFLICTS_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.USER_CONTEXT_REQUIRED, jsonConverter.readValue(USER_CONTEXT_REQUIRED_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.SUBSCRIPTION_ADD_ONS_PRESENT, jsonConverter.readValue(SUBSCRIPTION_ADD_ONS_PRESENT_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS, jsonConverter.readValue(SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.SUBSCRIPTION_TARGET_OFFER_NOT_FOUND, jsonConverter.readValue(SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_JSON, UpgradeErrorCode.class));
+        assertEquals(UpgradeErrorCode.SUBSCRIPTION_NOT_PROVISIONED, jsonConverter.readValue(SUBSCRIPTION_NOT_PROVISIONED_JSON, UpgradeErrorCode.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(OTHER_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.OTHER));
+        assertEquals(DELEGATED_ADMIN_PERMISSIONS_DISABLED_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.DELEGATED_ADMIN_PERMISSIONS_DISABLED));
+        assertEquals(SUBSCRIPTION_STATUS_NOT_ACTIVE_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.SUBSCRIPTION_STATUS_NOT_ACTIVE));
+        assertEquals(CONFLICTING_SERVICE_TYPES_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.CONFLICTING_SERVICE_TYPES));
+        assertEquals(CONCURRENCY_CONFLICTS_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.CONCURRENCY_CONFLICTS));
+        assertEquals(USER_CONTEXT_REQUIRED_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.USER_CONTEXT_REQUIRED));
+        assertEquals(SUBSCRIPTION_ADD_ONS_PRESENT_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.SUBSCRIPTION_ADD_ONS_PRESENT));
+        assertEquals(SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS));
+        assertEquals(SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.SUBSCRIPTION_TARGET_OFFER_NOT_FOUND));
+        assertEquals(SUBSCRIPTION_NOT_PROVISIONED_JSON, jsonConverter.writeValueAsString(UpgradeErrorCode.SUBSCRIPTION_NOT_PROVISIONED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(OTHER_VALUE, UpgradeErrorCode.OTHER.toString());
+        assertEquals(DELEGATED_ADMIN_PERMISSIONS_DISABLED_VALUE, UpgradeErrorCode.DELEGATED_ADMIN_PERMISSIONS_DISABLED.toString());
+        assertEquals(SUBSCRIPTION_STATUS_NOT_ACTIVE_VALUE, UpgradeErrorCode.SUBSCRIPTION_STATUS_NOT_ACTIVE.toString());
+        assertEquals(CONFLICTING_SERVICE_TYPES_VALUE, UpgradeErrorCode.CONFLICTING_SERVICE_TYPES.toString());
+        assertEquals(CONCURRENCY_CONFLICTS_VALUE, UpgradeErrorCode.CONCURRENCY_CONFLICTS.toString());
+        assertEquals(USER_CONTEXT_REQUIRED_VALUE, UpgradeErrorCode.USER_CONTEXT_REQUIRED.toString());
+        assertEquals(SUBSCRIPTION_ADD_ONS_PRESENT_VALUE, UpgradeErrorCode.SUBSCRIPTION_ADD_ONS_PRESENT.toString());
+        assertEquals(SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS_VALUE, UpgradeErrorCode.SUBSCRIPTION_DOES_NOT_HAVE_ANY_UPGRADE_PATHS.toString());
+        assertEquals(SUBSCRIPTION_TARGET_OFFER_NOT_FOUND_VALUE, UpgradeErrorCode.SUBSCRIPTION_TARGET_OFFER_NOT_FOUND.toString());
+        assertEquals(SUBSCRIPTION_NOT_PROVISIONED_VALUE, UpgradeErrorCode.SUBSCRIPTION_NOT_PROVISIONED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/subscriptions/UpgradeTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="UpgradeTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UpgradeTypeTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String UPGRADE_ONLY_VALUE = "upgrade_only";
+    private static final String UPGRADE_WITH_LICENSE_TRANSFER_VALUE = "upgrade_with_license_transfer";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String UPGRADE_ONLY_JSON = '"' + UPGRADE_ONLY_VALUE + '"';
+    private static final String UPGRADE_WITH_LICENSE_TRANSFER_JSON = '"' + UPGRADE_WITH_LICENSE_TRANSFER_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(UpgradeType.NONE, jsonConverter.readValue(NONE_JSON, UpgradeType.class));
+        assertEquals(UpgradeType.UPGRADE_ONLY, jsonConverter.readValue(UPGRADE_ONLY_JSON, UpgradeType.class));
+        assertEquals(UpgradeType.UPGRADE_WITH_LICENSE_TRANSFER, jsonConverter.readValue(UPGRADE_WITH_LICENSE_TRANSFER_JSON, UpgradeType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(UpgradeType.NONE));
+        assertEquals(UPGRADE_ONLY_JSON, jsonConverter.writeValueAsString(UpgradeType.UPGRADE_ONLY));
+        assertEquals(UPGRADE_WITH_LICENSE_TRANSFER_JSON, jsonConverter.writeValueAsString(UpgradeType.UPGRADE_WITH_LICENSE_TRANSFER));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, UpgradeType.NONE.toString());
+        assertEquals(UPGRADE_ONLY_VALUE, UpgradeType.UPGRADE_ONLY.toString());
+        assertEquals(UPGRADE_WITH_LICENSE_TRANSFER_VALUE, UpgradeType.UPGRADE_WITH_LICENSE_TRANSFER.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/users/UserDomainTypeTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/users/UserDomainTypeTest.java
@@ -1,0 +1,58 @@
+// -----------------------------------------------------------------------
+// <copyright file="UserDomainTypeTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.users;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserDomainTypeTest
+{
+    private static final String NONE_VALUE = "none";
+    private static final String MANAGED_VALUE = "managed";
+    private static final String FEDERATED_VALUE = "federated";
+    private static final String NONE_JSON = '"' + NONE_VALUE + '"';
+    private static final String MANAGED_JSON = '"' + MANAGED_VALUE + '"';
+    private static final String FEDERATED_JSON = '"' + FEDERATED_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(UserDomainType.NONE, jsonConverter.readValue(NONE_JSON, UserDomainType.class));
+        assertEquals(UserDomainType.MANAGED, jsonConverter.readValue(MANAGED_JSON, UserDomainType.class));
+        assertEquals(UserDomainType.FEDERATED, jsonConverter.readValue(FEDERATED_JSON, UserDomainType.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(NONE_JSON, jsonConverter.writeValueAsString(UserDomainType.NONE));
+        assertEquals(MANAGED_JSON, jsonConverter.writeValueAsString(UserDomainType.MANAGED));
+        assertEquals(FEDERATED_JSON, jsonConverter.writeValueAsString(UserDomainType.FEDERATED));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(NONE_VALUE, UserDomainType.NONE.toString());
+        assertEquals(MANAGED_VALUE, UserDomainType.MANAGED.toString());
+        assertEquals(FEDERATED_VALUE, UserDomainType.FEDERATED.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/users/UserStateTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/users/UserStateTest.java
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="UserStateTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.users;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserStateTest
+{
+    private static final String ACTIVE_VALUE = "active";
+    private static final String INACTIVE_VALUE = "inactive";
+    private static final String ACTIVE_JSON = '"' + ACTIVE_VALUE + '"';
+    private static final String INACTIVE_JSON = '"' + INACTIVE_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(UserState.ACTIVE, jsonConverter.readValue(ACTIVE_JSON, UserState.class));
+        assertEquals(UserState.INACTIVE, jsonConverter.readValue(INACTIVE_JSON, UserState.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(ACTIVE_JSON, jsonConverter.writeValueAsString(UserState.ACTIVE));
+        assertEquals(INACTIVE_JSON, jsonConverter.writeValueAsString(UserState.INACTIVE));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(ACTIVE_VALUE, UserState.ACTIVE.toString());
+        assertEquals(INACTIVE_VALUE, UserState.INACTIVE.toString());
+    }
+}

--- a/src/test/java/com/microsoft/store/partnercenter/models/utilizations/AzureUtilizationGranularityTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/utilizations/AzureUtilizationGranularityTest.java
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="AzureUtilizationGranularityTest.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.utilizations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AzureUtilizationGranularityTest
+{
+    private static final String DAILY_VALUE = "daily";
+    private static final String HOURLY_VALUE = "hourly";
+    private static final String DAILY_JSON = '"' + DAILY_VALUE + '"';
+    private static final String HOURLY_JSON = '"' + HOURLY_VALUE + '"';
+
+    private ObjectMapper jsonConverter;
+
+    @BeforeEach
+    void setUp()
+    {
+        jsonConverter = TestJsonConverter.create();
+    }
+
+    @Test
+    void createFromJson() throws IOException
+    {
+        assertEquals(AzureUtilizationGranularity.DAILY, jsonConverter.readValue(DAILY_JSON, AzureUtilizationGranularity.class));
+        assertEquals(AzureUtilizationGranularity.HOURLY, jsonConverter.readValue(HOURLY_JSON, AzureUtilizationGranularity.class));
+    }
+
+    @Test
+    void writeToJson() throws IOException
+    {
+        assertEquals(DAILY_JSON, jsonConverter.writeValueAsString(AzureUtilizationGranularity.DAILY));
+        assertEquals(HOURLY_JSON, jsonConverter.writeValueAsString(AzureUtilizationGranularity.HOURLY));
+    }
+
+    @Test
+    void convertToString()
+    {
+        assertEquals(DAILY_VALUE, AzureUtilizationGranularity.DAILY.toString());
+        assertEquals(HOURLY_VALUE, AzureUtilizationGranularity.HOURLY.toString());
+    }
+}


### PR DESCRIPTION
Override toString in enums:
* In enums override toString() method for fetching a correct value
* Add unit-tests for enums

# Description

In the previous commit, `enums` were updated and it became the cause incorrect converting to string values.

This patch adds overloading of the toString method and covered all changed enums with unit-tests.