### PR TITLE
Entitlment, invoice, order, product, and validation feature update

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,7 @@
   * Modified the target JDK from 1.8 to 1.7
 * Orders
   * Added the ability to get the activation link for an order line item
+  * Added the ability to get the provisioning status for an order
   * Added the ability to include pricing details in the order information returned when requesting a list of customer orders
 * Products
   * Added the following properties to the Availability model

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,10 +24,26 @@
 
 * Auditing
   * Added new operation and resource types
+* Devices
+  * Addressed issue with the device update operation
 * Entitlements
+  * Added the ability to obtain the expiration date for the entitlement (if applicable)
   * Added the AlternateId property to the reference order object
+  * Added the following properties to the Entitlement model
+    * FulfillmentState
+    * ExpiryDate
 * Invoices
   * Added the ability to download the tax receipt
+  * Added the following properties to the OneTimeInvoiceLineItem model
+    * AlternateId
+    * ChargeEndDate
+    * ChargeStartDate
+    * PublisherId
+    * PublisherName
+    * SubscriptionDescription
+    * SubscriptionId
+    * TermAndBillingCycle
+    * UnitType
   * Changed the the following types of the AzureDataMarketLineItem class from int to double
     * ConsumptionDiscount
     * ConsumptionPrice
@@ -45,15 +61,25 @@
   * Modified the target JDK from 1.8 to 1.7
 * Orders
   * Added the ability to get the activation link for an order line item
-  * Added the ability to get the provisioning status for an order
-  * Added the ability to include pricing details when requesting order information
+  * Added the ability to include pricing details in the order information returned when requesting a list of customer orders
 * Products
+  * Added the following properties to the Availability model
+    * IsPurchasable
+    * IsRenewable
+    * Terms
+  * Added the following properties to the Product model
+    * IsMicrosoftProduct
+    * PublisherName
   * Removed the SKU download operations
+* Qualifications
+  * Added the ability to update the customer qualification used for Government Community Cloud.
 * Rate Card
   * Changed the following type of the AzureMeter class from int to double IncludedQuantity
 * Subscriptions
   * Changed the type for the commitment end date from LocalDateTime to DateTime
   * Changed the type for the effective start date from LocalDateTime to DateTime
+* Validations
+  * Added the ability to request validation codes used to create Government Community Cloud customers
 
 ## Version 1.10.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,18 +44,6 @@
     * SubscriptionId
     * TermAndBillingCycle
     * UnitType
-  * Changed the the following types of the AzureDataMarketLineItem class from int to double
-    * ConsumptionDiscount
-    * ConsumptionPrice
-    * IncludedQuantity
-    * ListPrice
-    * OverageQuantity
-    * PostTaxEffectiveRate
-    * PostTaxTotal
-    * PretaxEffectiveRate
-    * PretaxCharges
-    * TaxAmount
-  * Changed the following type of the BaseAzureDataMarketLineItem class from int to double ConsumedQuantity
   * Removed Azure Data Market billing provider type and models because this is no longer supported
 * JDK
   * Modified the target JDK from 1.8 to 1.7

--- a/src/main/java/com/microsoft/store/partnercenter/PartnerService.java
+++ b/src/main/java/com/microsoft/store/partnercenter/PartnerService.java
@@ -34,7 +34,7 @@ public class PartnerService
 	private PartnerService()
 	{
 		// set the global partner service properties
-		setConfiguration( readPartnerSdkConfiguration() );
+		setConfiguration( readPartnerServiceConfiguration() );
 		setApiRootUrl( configuration.getPartnerServiceApiRoot() );
 		setPartnerServiceApiVersion( configuration.getPartnerServiceApiVersion() );    	
 
@@ -216,11 +216,11 @@ public class PartnerService
 	 * 
 	 * @return The partner SDK configuration.
 	 */
-	private Configuration readPartnerSdkConfiguration()
+	private Configuration readPartnerServiceConfiguration()
 	{
 		ObjectMapper mapper = new ObjectMapper();
 		InputStream is =
-			PartnerService.class.getClassLoader().getResourceAsStream( "PartnerSdkConfiguration.json" );
+			PartnerService.class.getClassLoader().getResourceAsStream( "PartnerService.json" );
 		try
 		{
 			return mapper.readValue( is, Configuration.class );

--- a/src/main/java/com/microsoft/store/partnercenter/devicesdeployment/IBatchJobStatusCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/devicesdeployment/IBatchJobStatusCollection.java
@@ -22,5 +22,5 @@ public interface IBatchJobStatusCollection
 	 * @param trackingId The tracking identifier.
 	 * @return The customer's devices batch upload status operations.
 	 */
-    IBatchJobStatus byId( String trackingId );
+    IBatchJobStatus byId(String trackingId);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/entitlements/EntitlementCollectionByEntitlementTypeOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/entitlements/EntitlementCollectionByEntitlementTypeOperations.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponent;
 import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
-import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.entitlements.Entitlement;
 import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
@@ -26,7 +25,7 @@ import com.microsoft.store.partnercenter.utils.StringHelper;
  */
 public class EntitlementCollectionByEntitlementTypeOperations
 	extends BasePartnerComponent<Tuple<String, String>>
-	implements IEntireEntityCollectionRetrievalOperations<Entitlement, ResourceCollection<Entitlement>>
+	implements IEntitlementCollectionByEntitlementType
 {
 	/**
 	 * Initializes a new instance of the EntitlementCollectionByEntitlementTypeOperations class.
@@ -37,26 +36,38 @@ public class EntitlementCollectionByEntitlementTypeOperations
 	 */
 	public EntitlementCollectionByEntitlementTypeOperations( IPartner rootPartnerOperations, String customerId, String entitlementType )
 	{
-		super( rootPartnerOperations, new Tuple<String, String>(customerId, entitlementType) );
+		super(rootPartnerOperations, new Tuple<String, String>(customerId, entitlementType));
 
-		if ( StringHelper.isNullOrWhiteSpace( customerId ) )
+		if (StringHelper.isNullOrWhiteSpace(customerId))
 		{
-			throw new IllegalArgumentException( "customerId must be set" );
+			throw new IllegalArgumentException("customerId must be set");
 		}
 
-		if ( StringHelper.isNullOrWhiteSpace( entitlementType ) )
+		if (StringHelper.isNullOrWhiteSpace(entitlementType))
 		{
-			throw new IllegalArgumentException( "entitlementType must be set" );
+			throw new IllegalArgumentException("entitlementType must be set");
 		}
 	}
 
-	/**
-	 * Retrieves entitlement collection with the given entitlement type.
-	 * 
-	 * @return The entitlement collection with the given entitlement type.
-	 */
+    /**
+     * Gets an entitlement collection with the given entitlement type.
+     * 
+     * @return The collection of entitlements corresponding to a specific entitlement type for the customer.
+     */
 	@Override
 	public ResourceCollection<Entitlement> get()
+	{
+		return get(false);
+	}
+
+	/**
+     * Gets an entitlement collection with the given entitlement type.
+     * 
+     * @param showExpiry A flag to indicate if the expiry date is required to be returned along with the entitlement (if applicable).
+     * @return The collection of entitlements corresponding to a specific entitlement type for the customer.
+     */
+	@Override
+	public ResourceCollection<Entitlement> get(Boolean showExpiry)
 	{
 		Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
 
@@ -66,6 +77,15 @@ public class EntitlementCollectionByEntitlementTypeOperations
 			(
 				PartnerService.getInstance().getConfiguration().getApis().get("GetEntitlements").getParameters().get("EntitlementType"),
 				this.getContext().getItem2()
+			) 
+		);
+
+		parameters.add
+		(
+			new KeyValuePair<String, String>
+			(
+				PartnerService.getInstance().getConfiguration().getApis().get("GetEntitlements").getParameters().get("ShowExpiry"),
+				String.valueOf(showExpiry)
 			) 
 		);
 

--- a/src/main/java/com/microsoft/store/partnercenter/entitlements/EntitlementCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/entitlements/EntitlementCollectionOperations.java
@@ -7,6 +7,8 @@
 package com.microsoft.store.partnercenter.entitlements;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponentString;
@@ -15,6 +17,7 @@ import com.microsoft.store.partnercenter.PartnerService;
 import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.entitlements.Entitlement;
+import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
@@ -52,19 +55,44 @@ public class EntitlementCollectionOperations
 		return new EntitlementCollectionByEntitlementTypeOperations(this.getPartner(), this.getContext(), entitlementType);
 	}
 
-	/**
-	 * Retrieves the entitlement collection.
-	 * 
-	 * @return The entitlement collection.
-	 */
+    /**
+     * Gets the entitlements for a customer.
+     * 
+     * @param  A flag to indicate if the expiry date is required to be returned along with the entitlement (if applicable).
+     * @return The collection of entitlements for the customer.
+     */
 	@Override
 	public ResourceCollection<Entitlement> get()
+	{	
+		return get(false);
+	}
+
+	/**
+     * Gets the entitlements for a customer.
+     * 
+     * @param showExpiry A flag to indicate if the expiry date is required to be returned along with the entitlement (if applicable).
+     * @return The collection of entitlements for the customer.
+     */
+	@Override
+	public ResourceCollection<Entitlement> get(Boolean showExpiry)
 	{
+		Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
+
+		parameters.add
+		(
+			new KeyValuePair<String, String>
+			(
+				PartnerService.getInstance().getConfiguration().getApis().get("GetEntitlements").getParameters().get("ShowExpiry"),
+				String.valueOf(showExpiry)
+			) 
+		);
+		
 		return this.getPartner().getServiceClient().get(
 			this.getPartner(),
 			new TypeReference<ResourceCollection<Entitlement>>(){}, 
 			MessageFormat.format(
 				PartnerService.getInstance().getConfiguration().getApis().get("GetEntitlements").getPath(),
-				this.getContext()));
+				this.getContext()),
+			parameters);
 	}
 }

--- a/src/main/java/com/microsoft/store/partnercenter/entitlements/IEntitlementCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/entitlements/IEntitlementCollection.java
@@ -12,7 +12,7 @@ import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.entitlements.Entitlement;
 
 /**
- *  Holds operations that can be performed on entitlements associated to the customer based on the logged in partner.
+ *  Represents the operations that can be performed on entitlements associated to the customer based on the logged in partner.
  */
 public interface IEntitlementCollection 
 	extends IPartnerComponentString, IEntireEntityCollectionRetrievalOperations<Entitlement, ResourceCollection<Entitlement>>
@@ -24,4 +24,12 @@ public interface IEntitlementCollection
 	 * @return The entitlement collection operations by entitlement type.
 	 */
      IEntireEntityCollectionRetrievalOperations<Entitlement, ResourceCollection<Entitlement>> byEntitlementType(String entitlementType);
+
+    /**
+     * Gets the entitlements for a customer.
+     * 
+     * @param showExpiry A flag to indicate if the expiry date is required to be returned along with the entitlement (if applicable).
+     * @return The collection of entitlements for the customer.
+     */
+    ResourceCollection<Entitlement> get(Boolean showExpiry);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/entitlements/IEntitlementCollectionByEntitlementType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/entitlements/IEntitlementCollectionByEntitlementType.java
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+// <copyright file="IEntitlementCollectionByEntitlementType.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.entitlements;
+
+import com.microsoft.store.partnercenter.IPartnerComponent;
+import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.entitlements.Entitlement;
+import com.microsoft.store.partnercenter.models.utils.Tuple;
+
+/**
+ *  Represents the operations that can be performed on entitlements (by type) associated to the customer based on the logged in partner.
+ */
+public interface IEntitlementCollectionByEntitlementType 
+	extends IPartnerComponent<Tuple<String, String>>, IEntireEntityCollectionRetrievalOperations<Entitlement, ResourceCollection<Entitlement>>
+{
+    /**
+     * Gets an entitlement collection with the given entitlement type.
+     * 
+     * @param showExpiry A flag to indicate if the expiry date is required to be returned along with the entitlement (if applicable).
+     * @return The collection of entitlements corresponding to a specific entitlement type for the customer.
+     */
+    ResourceCollection<Entitlement> get(Boolean showExpiry);
+}

--- a/src/main/java/com/microsoft/store/partnercenter/genericoperations/IEntitySelector.java
+++ b/src/main/java/com/microsoft/store/partnercenter/genericoperations/IEntitySelector.java
@@ -6,12 +6,12 @@
 
 package com.microsoft.store.partnercenter.genericoperations;
 
-public interface IEntitySelector<TType, TEntity>
+public interface IEntitySelector<TTYpe, TEntity>
 {
     /**
      * Retrieves the behavior for an entity using the entity's identifier.
      * @param id The entity's identifier.
      * @return The entity's behavior.
      */
-    TEntity byId( TType id );
+    TEntity byId(TTYpe id);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/invoices/IInvoice.java
+++ b/src/main/java/com/microsoft/store/partnercenter/invoices/IInvoice.java
@@ -8,6 +8,7 @@ package com.microsoft.store.partnercenter.invoices;
 
 import com.microsoft.store.partnercenter.IPartnerComponentString;
 import com.microsoft.store.partnercenter.genericoperations.IEntityGetOperations;
+import com.microsoft.store.partnercenter.models.invoices.BillingPeriod;
 import com.microsoft.store.partnercenter.models.invoices.BillingProvider;
 import com.microsoft.store.partnercenter.models.invoices.Invoice;
 import com.microsoft.store.partnercenter.models.invoices.InvoiceLineItemType;
@@ -40,11 +41,25 @@ public interface IInvoice
      * @return The invoice line item collection operations.
      */
     IInvoiceLineItemCollection by(BillingProvider billingProvider, InvoiceLineItemType invoiceLineItemType);
-    
+ 
     /**
-     * Retrieves the invoice. This operation is currently only supported for user based credentials.
+     * Creates an invoice line item collection operations given a billing provider and invoice line item type.
      * 
-     * @return The invoice.
+     * @param provider The type of billing provider.
+     * @param invoiceLineItemType The type of invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The period for unbilled recon.
      */
-    Invoice get();
+    IReconLineItemCollection By(BillingProvider provider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period);
+
+    /**
+     * Creates an invoice line item collection operations given a billing provider and invoice line item type.
+     * 
+     * @param provider The type of billing provider.
+     * @param invoiceLineItemType The type of invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The period for unbilled recon.
+     * @param pageSize The number of records returned in a single operation.
+     */
+    IReconLineItemCollection By(BillingProvider provider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period, int pageSize);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/invoices/IReconLineItemCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/invoices/IReconLineItemCollection.java
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="IReconLineItemCollection.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.invoices;
+
+import com.microsoft.store.partnercenter.IPartnerComponent;
+import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
+import com.microsoft.store.partnercenter.models.SeekBasedResourceCollection;
+import com.microsoft.store.partnercenter.models.invoices.InvoiceLineItem;
+
+/**
+ * Represents the operations that can be done on partner's recon line items.
+ */
+public interface IReconLineItemCollection 
+    extends IPartnerComponent<String>, IEntireEntityCollectionRetrievalOperations<InvoiceLineItem, SeekBasedResourceCollection<InvoiceLineItem>>
+{
+}

--- a/src/main/java/com/microsoft/store/partnercenter/invoices/InvoiceCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/invoices/InvoiceCollection.java
@@ -124,7 +124,7 @@ public class InvoiceCollection
 	 * @return The subset of invoices.
 	 */
 	@Override
-	public SeekBasedResourceCollection<Invoice> get( int offset, int size )
+	public SeekBasedResourceCollection<Invoice> get(int offset, int size)
 	{
 		ParameterValidator.isIntInclusive( 0, Integer.MAX_VALUE, offset,
 										   "The value of the page offset should be at least 0." );

--- a/src/main/java/com/microsoft/store/partnercenter/invoices/InvoiceOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/invoices/InvoiceOperations.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponentString;
 import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.invoices.BillingPeriod;
 import com.microsoft.store.partnercenter.models.invoices.BillingProvider;
 import com.microsoft.store.partnercenter.models.invoices.Invoice;
 import com.microsoft.store.partnercenter.models.invoices.InvoiceLineItemType;
@@ -69,6 +70,47 @@ public class InvoiceOperations
 	public IInvoiceLineItemCollection by( BillingProvider billingProvider, InvoiceLineItemType invoiceLineItemType )
 	{
 		return new InvoiceLineItemCollectionOperations( this.getPartner(), this.getContext(), billingProvider, invoiceLineItemType );
+	}
+
+    /**
+     * Creates an invoice line item collection operations given a billing provider and invoice line item type.
+     * 
+     * @param provider The type of billing provider.
+     * @param invoiceLineItemType The type of invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The period for unbilled recon.
+     * @param pageSize The number of records returned in a single operation.
+     */
+	public IReconLineItemCollection By(BillingProvider provider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period)
+	{
+		return new ReconLineItemCollectionOperations(
+			this.getPartner(), 
+			this.getContext(), 
+			provider, 
+			invoiceLineItemType, 
+			currencyCode, 
+			period);
+	}
+
+    /**
+     * Creates an invoice line item collection operations given a billing provider and invoice line item type.
+     * 
+     * @param provider The type of billing provider.
+     * @param invoiceLineItemType The type of invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The period for unbilled recon.
+     * @param pageSize The number of records returned in a single operation.
+     */
+	public IReconLineItemCollection By(BillingProvider provider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period, int pageSize)
+	{
+		return new ReconLineItemCollectionOperations(
+			this.getPartner(), 
+			this.getContext(), 
+			provider, 
+			invoiceLineItemType, 
+			currencyCode, 
+			period, 
+			pageSize);
 	}
 
 	/**

--- a/src/main/java/com/microsoft/store/partnercenter/invoices/ReconLineItemCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/invoices/ReconLineItemCollectionOperations.java
@@ -1,0 +1,170 @@
+// -----------------------------------------------------------------------
+// <copyright file="ReconLineItemCollectionOperations.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.invoices;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.store.partnercenter.BasePartnerComponent;
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.SeekBasedResourceCollection;
+import com.microsoft.store.partnercenter.models.invoices.BillingPeriod;
+import com.microsoft.store.partnercenter.models.invoices.BillingProvider;
+import com.microsoft.store.partnercenter.models.invoices.InvoiceLineItem;
+import com.microsoft.store.partnercenter.models.invoices.InvoiceLineItemType;
+import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
+import com.microsoft.store.partnercenter.utils.StringHelper;
+
+/**
+ * Represents the operations that can be done on partner's recon line items.
+ */
+public class ReconLineItemCollectionOperations 
+    extends BasePartnerComponent<String>
+    implements IReconLineItemCollection 
+{
+    /**
+     * The maximum page size for recon line items.
+     */
+    private final int maxPageSizeReconLineItems = 2000;
+
+    /**
+     * The type of billing provider.
+     */
+    private BillingProvider billingProvider;
+
+    /**
+     * The currency code.
+     */
+    private String currencyCode;
+
+    /**
+     * The type of invoice line item.
+     */
+    private InvoiceLineItemType invoiceLineItemType;
+
+    /**
+     * The page size;
+     */
+    private int pageSize; 
+
+    /**
+     * The billing period.
+     */
+    private BillingPeriod period;
+
+	/**
+	 * Initializes a new instance of the ReconLineItemCollectionOperations class.
+	 * 
+	 * @param rootPartnerOperations The root partner operations instance.
+	 * @param invoiceId The invoice identifier.
+     * @param billingProvider The billing provider type.
+     * @param invoiceLineItemType The invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The billing period.
+	 */
+	public ReconLineItemCollectionOperations(IPartner rootPartnerOperations, String invoiceId, BillingProvider billingProvider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period)
+	{
+        super(rootPartnerOperations, invoiceId);
+
+        if (StringHelper.isNullOrWhiteSpace(invoiceId))
+		{
+			throw new IllegalArgumentException("invoiceId must be set");
+        }
+
+        if (StringHelper.isNullOrWhiteSpace(currencyCode))
+        {
+			throw new IllegalArgumentException("currencyCode must be set");
+        }
+
+        this.billingProvider = billingProvider;
+        this.invoiceLineItemType = invoiceLineItemType;
+        this.currencyCode = currencyCode;
+        this.period = period;
+
+        pageSize = maxPageSizeReconLineItems;
+    }
+
+    /**
+	 * Initializes a new instance of the ReconLineItemCollectionOperations class.
+	 * 
+	 * @param rootPartnerOperations The root partner operations instance.
+	 * @param invoiceId The invoice identifier.
+     * @param billingProvider The billing provider type.
+     * @param invoiceLineItemType The invoice line item type.
+     * @param currencyCode The currency code.
+     * @param period The billing period.
+     * @param pageSize The number of records returned in a single operation.
+	 */
+	public ReconLineItemCollectionOperations(IPartner rootPartnerOperations, String invoiceId, BillingProvider billingProvider, InvoiceLineItemType invoiceLineItemType, String currencyCode, BillingPeriod period, int pageSize)
+	{
+        super(rootPartnerOperations, invoiceId);
+
+        if (StringHelper.isNullOrWhiteSpace(invoiceId))
+		{
+			throw new IllegalArgumentException("invoiceId must be set");
+        }
+
+        if (StringHelper.isNullOrWhiteSpace(currencyCode))
+        {
+			throw new IllegalArgumentException("currencyCode must be set");
+        }
+
+        this.billingProvider = billingProvider;
+        this.invoiceLineItemType = invoiceLineItemType;
+        this.currencyCode = currencyCode;
+        this.period = period;
+
+        this.pageSize = pageSize;
+    }
+    
+    /**
+     * Gets the recon line items collection of the partner.
+     * 
+     * @return The collection of recon line items.
+     */
+    @Override
+    public SeekBasedResourceCollection<InvoiceLineItem> get() 
+    {
+        Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
+
+		parameters.add(
+			new KeyValuePair<String, String>(
+				PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getParameters().get("CurrencyCode"),
+                currencyCode));
+        
+        parameters.add(
+            new KeyValuePair<String, String>(
+                PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getParameters().get("InvoiceLineItemType"),
+                invoiceLineItemType.toString()));
+
+        parameters.add(
+            new KeyValuePair<String, String>(
+                PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getParameters().get("Period"),
+                period.toString()));
+
+        parameters.add(
+            new KeyValuePair<String, String>(
+                PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getParameters().get("Provider"),
+                billingProvider.toString()));
+
+        parameters.add(
+            new KeyValuePair<String, String>(
+                PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getParameters().get("Size"),
+                String.valueOf(pageSize)));
+
+		return this.getPartner().getServiceClient().get(
+			this.getPartner(),
+			new TypeReference<SeekBasedResourceCollection<InvoiceLineItem>>(){}, 
+			MessageFormat.format( 
+				PartnerService.getInstance().getConfiguration().getApis().get("GetReconLineItems").getPath(),
+                this.getContext()),
+            parameters);
+    }
+}

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/OperationType.java
@@ -196,9 +196,9 @@ public enum OperationType
     /**
      * The credit limit for the partner was increased.
      */
-    INCREASE_CREDIT_LIMIT("increase_credit_limit"), 
-    
-    /**
+    INCREASE_CREDIT_LIMIT("increase_credit_limit"),
+	
+	/**
      * An invoice was created.
      */
     CREATE_INVOICE("create_invoice");

--- a/src/main/java/com/microsoft/store/partnercenter/models/auditing/ResourceType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/auditing/ResourceType.java
@@ -97,9 +97,9 @@ public enum ResourceType
      * The credit limit resource
      */
     CREDIT_LIMIT("credit_limit"),
-    
-    /**
-     * THe invoice resource
+	
+	/**
+     * The invoice resource
      */
     INVOICE("invoice");
 

--- a/src/main/java/com/microsoft/store/partnercenter/models/entitlements/Entitlement.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/entitlements/Entitlement.java
@@ -6,9 +6,10 @@
 
 package com.microsoft.store.partnercenter.models.entitlements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.store.partnercenter.models.ResourceBaseWithLinks;
 import com.microsoft.store.partnercenter.models.StandardResourceLinks;
+
+import org.joda.time.DateTime;
 
 /**
  * Class that represents an entitlement.
@@ -16,28 +17,30 @@ import com.microsoft.store.partnercenter.models.StandardResourceLinks;
 public class Entitlement
 	 extends ResourceBaseWithLinks<StandardResourceLinks> 
 {
-	@JsonProperty("entitledArtifacts")
 	private Iterable<Artifact> entitledArtifacts;
 
-	@JsonProperty("entitlementType")
 	private String entitlementType;
 
-	@JsonProperty("includedEntitlements")
+	/**
+	 * The entitlement expiry date for the entitlement.
+	 */
+	private DateTime expiryDate;
+
+	/**
+	 * The fulfillment state for the entitlement.
+	 */
+	private String fulfillmentState;
+
 	private Iterable<Entitlement> includedEntitlements;
 
-	@JsonProperty("productId")
 	private String productId;
 
-	@JsonProperty("quantity")
 	private Integer quantity;
 
-	@JsonProperty("quantityDetails")
 	private Iterable<QuantityDetail> quantityDetails;
 
-	@JsonProperty("referenceOrder")
 	private ReferenceOrder referenceOrder;
 
-	@JsonProperty("skuId")
 	private String skuId;
 
 	/**
@@ -78,6 +81,44 @@ public class Entitlement
 	public void setEntitlementType(String value)
 	{
 		entitlementType = value;
+	}
+
+	/**
+	 * Gets the expiry date for the entitlement.
+	 * 
+	 * @return The expiry date for the entitlement.
+	 */
+	public DateTime getExpiryDate()
+	{
+		return expiryDate;
+	}
+
+	/**
+	 * Sets the expiry date for the entitlement.
+	 * 
+	 * @param value The expiry date for the entitlement.
+	 */
+	public void setExpiryDate(DateTime value)
+	{
+		expiryDate = value;
+	}
+
+	/**
+	 * Gets the fulfillment state for the entitlement.
+	 */
+	public String getFulfillmentState()
+	{
+		return fulfillmentState;
+	}
+
+	/**
+	 * Sets the fulfillment state for the entitlement.
+	 * 
+	 * @param value The the fulfillment state for the entitlement.
+	 */
+	public void setFulfillmentState(String value)
+	{
+		fulfillmentState = value;
 	}
 
 	/**

--- a/src/main/java/com/microsoft/store/partnercenter/models/entitlements/ReferenceOrder.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/entitlements/ReferenceOrder.java
@@ -6,7 +6,6 @@
 
 package com.microsoft.store.partnercenter.models.entitlements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.store.partnercenter.models.ResourceBaseWithLinks;
 import com.microsoft.store.partnercenter.models.StandardResourceLinks;
 
@@ -16,13 +15,19 @@ import com.microsoft.store.partnercenter.models.StandardResourceLinks;
 public class ReferenceOrder
 	 extends ResourceBaseWithLinks<StandardResourceLinks> 
 {
-	@JsonProperty("alternateId")
+	/**
+	 * The alternate identifier value.
+	 */
 	private String alternateId; 
 
-	@JsonProperty("id")
+	/**
+	 * The identifier for the reference order.
+	 */
 	private String id;
 
-	@JsonProperty("lineItemId")
+	/**
+	 * The line item identifier.
+	 */
 	private String lineItemId;
 	
 	/**

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingPeriod.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/BillingPeriod.java
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------
-// <copyright file="BillingProvider.java" company="Microsoft Corporation">
+// <copyright file="BillingPeriod.java" company="Microsoft Corporation">
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // </copyright>
 // ----------------------------------------------------------------
@@ -8,41 +8,26 @@ package com.microsoft.store.partnercenter.models.invoices;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BillingProvider
+public enum BillingPeriod
 {
     /**
-     * Different providers of billing information Enum initializer
+     * Default period, does not mean anything.
      */
     NONE("none"),
 
     /**
-    * Bill is provided by Office. Example: O365, and In-tune.
+    * The current period that is ongoing.
     */
-    OFFICE("office"),
+    Current("current"),
 
     /**
-    * Bill is provided by Azure. Example: Azure Services.
+    * The previous period.
     */
-    AZURE("azure"),
-
-    /**
-    * Bill is provided for one time purchases.
-    */
-    ONE_TIME("oneTime"),
-    
-    /**
-     * Indicates that the provider is marketplace .
-     */
-    MARKETPLACE("marketplace"), 
-    
-    /**
-     * Indicates that the provider is both first party and marketplace.
-     */
-    ALL("all");
+    PREVIOUS("previous");
 
     private final String value;
 
-    BillingProvider(String value)
+    BillingPeriod(String value)
     {
         this.value = value;
     }

--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/OneTimeInvoiceLineItem.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/OneTimeInvoiceLineItem.java
@@ -15,7 +15,232 @@ public class OneTimeInvoiceLineItem
     extends InvoiceLineItem
 {
     /**
-     * Gets or sets the partner commerce account Id.
+     * The alternate identifier (quote identifier).
+     */
+    private String alternateId;
+
+    /**
+     * The charge end date associated with this purchase.
+     */
+    private DateTime chargeEndDate;
+
+    /**
+     * The charge start date associated with this purchase.
+     */
+    private DateTime chargeStarDate;
+
+    /**
+     * The publisher identifier associated with this purchase.
+     */
+    private String publisherId;
+
+    /**
+     * The publisher name associated with this purchase.
+     */
+    private String publisherName;
+
+    /**
+     * The subscription description associated with this purchase.
+     */
+    private String subscriptionDescription;
+
+    /**
+     * The subscription id associated with this purchase.
+     */
+    private String subscriptionId;
+
+    /**
+     * The term and billing cycle associated with this purchase. 
+     */
+    private String termAndBillingCycle;
+    
+    /**
+     * The type of unit.
+     */
+    private String unitType;
+
+    /**
+     * Gets the alternate identifier (quote identifier).
+     * 
+     * @return The alternate identifier (quote identifier).
+     */
+    public String getAlternateId()
+    {
+        return alternateId;
+    }
+
+    /**
+     * Sets the alternate identifier (quote identifier).
+     * 
+     * @param value The alternate identifier (quote identifier).
+     */
+    public void setAlternateId(String value)
+    {
+        alternateId = value;
+    }
+
+    /**
+     * Gets the charge end date associated with this purchase.
+     * 
+     * @return The charge end date associated with this purchase.
+     */
+    public DateTime getChargeEndDate()
+    {
+        return chargeEndDate;
+    }
+
+    /**
+     * Sets the charge end date associated with this purchase.
+     * 
+     * @param value The charge end date associated with this purchase.
+     */
+    public void setChargeEndDate(DateTime value)    
+    {
+        chargeEndDate = value;
+    }
+
+    /**
+     * Gets the charge start date associated with this purchase.
+     * 
+     * @return The charge start date associated with this purchase.
+     */
+    public DateTime getChargeStartDate()
+    {
+        return chargeStarDate;
+    }
+
+    /**
+     * Sets the charge start date associated with this purchase.
+     * 
+     * @param value The charge start date associated with this purchase.
+     */
+    public void setChargeStartDate(DateTime value)    
+    {
+        chargeStarDate = value;
+    }
+
+    /**
+     * Gets the publisher identifier associated with this purchase.
+     * 
+     * @return The publisher identifier associated with this purchase.
+     */
+    public String getPublisherId()
+    {
+        return publisherId;
+    }
+
+    /**
+     * Sets the publisher identifier associated with this purchase.
+     * 
+     * @param value The publisher identifier associated with this purchase.
+     */
+    public void setPublisherId(String value)    
+    {
+        publisherId = value;
+    }
+
+    /**
+     * Gets the publisher name associated with this purchase.
+     * 
+     * @return The publisher name associated with this purchase.
+     */
+    public String getPublisherName()
+    {
+        return publisherName;
+    }
+
+    /**
+     * Sets the publisher name associated with this purchase.
+     * 
+     * @param value The publisher name associated with this purchase.
+     */
+    public void setPublisherName(String value)    
+    {
+        publisherName = value;
+    }
+
+    /**
+     * Gets the subscription description associated with this purchase.
+     * 
+     * @return The subscription description associated with this purchase.
+     */
+    public String getSubscriptionDescription()
+    {
+        return subscriptionDescription;
+    }
+
+    /**
+     * Sets the subscription description associated with this purchase.
+     * 
+     * @param value The subscription description associated with this purchase.
+     */
+    public void setSubscriptionDescription(String value)    
+    {
+        subscriptionDescription = value;
+    }
+
+    /**
+     * Gets the subscription identifier associated with this purchase.
+     * 
+     * @return The subscription identifier associated with this purchase.
+     */
+    public String getSubscriptionId()
+    {
+        return subscriptionId;
+    }
+
+    /**
+     * Sets the subscription identifier associated with this purchase.
+     * 
+     * @param value The subscription identifier associated with this purchase.
+     */
+    public void setSubscriptionId(String value)    
+    {
+        subscriptionId = value;
+    }
+
+    /**
+     * Gets the term and billing cycle associated with this purchase. 
+     * 
+     * @return The term and billing cycle associated with this purchase. 
+     */
+    public String getTermAndBillingCycle()
+    {
+        return termAndBillingCycle;
+    }
+
+    /**
+     * Sets term and billing cycle associated with this purchase. 
+     * 
+     * @param value The term and billing cycle associated with this purchase. 
+     */
+    public void setTermAndBillingCycle(String value)    
+    {
+        termAndBillingCycle = value;
+    }
+
+    /**
+     * Gets the type of unit. 
+     * 
+     * @return The type of unit.
+     */
+    public String getUnitType()
+    {
+        return unitType;
+    }
+
+    /**
+     * Sets type of unit.
+     * 
+     * @param value The type of unit.
+     */
+    public void setUnitType(String value)    
+    {
+        unitType = value;
+    }
+
+    /**
+     * Gets or sets the partner commerce account identifier.
      */
     private String partnerId;
 

--- a/src/main/java/com/microsoft/store/partnercenter/models/orders/Order.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/orders/Order.java
@@ -22,14 +22,13 @@ public class Order
     /**
      * The total price for the order.
      */
-    @JsonProperty("totalPrice")
     private double totalPrice;
 
-    /** 
+	/** 
      * The transaction type for the order.
      */
-    @JsonProperty("tranactionType")
     private String transactionType;
+
 
     /**
      * Gets or sets the order identifier.
@@ -158,6 +157,7 @@ public class Order
     {
         __BillingCycle = value;
     }
+
 
     /**
      * Gets the total price for the order. Order price (will not be returned unless explicitly asked for) Note: this information is PRE-TAX.

--- a/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItem.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItem.java
@@ -152,7 +152,7 @@ public class OrderLineItem
         __ProvisioningContext = value;
     }
 
-    /**
+	/**
      * Gets the pricing for the order line item.
      * 
      * @return The pricing for the order line item.

--- a/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItemActivationLink.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItemActivationLink.java
@@ -18,13 +18,13 @@ public class OrderLineItemActivationLink
      */
     private int lineItemNumber;
 
-    /** 
+    /**
      * The activation link for the order line item.
      */
     private Link link;
 
     /**
-     * Gets the order line number.
+     * Gets the order line item number.
      * 
      * @return The order line item number.
      */
@@ -44,9 +44,9 @@ public class OrderLineItemActivationLink
     }
 
     /**
-     * Gets the order line activation link.
+     * Gets the activation link.
      * 
-     * @return The activation linke for the order line item.
+     * @return The activation link for the order line item.
      */
     public Link getLink()
     {
@@ -54,9 +54,9 @@ public class OrderLineItemActivationLink
     }
 
     /**
-     * Sets the order line activation link.
+     * Sets the activation link.
      * 
-     * @param value The order line activation link.
+     * @param value The activation link.
      */
     public void setLink(Link value)
     {

--- a/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItemProvisioningStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/orders/OrderLineItemProvisioningStatus.java
@@ -9,15 +9,15 @@ package com.microsoft.store.partnercenter.models.orders;
 import com.microsoft.store.partnercenter.models.ResourceBase;
 
 /**
- * Order line item provisioning status.
+ * Represents the order line item provisioning status.
  */
-public class OrderLineItemProvisioningStatus
+public class OrderLineItemProvisioningStatus 
     extends ResourceBase
 {
     /**
      * The order line item number.
      */
-    private int lineItemNumber; 
+    private int lineItemNumber;
 
     /**
      * The quantity provisioning information.
@@ -25,7 +25,7 @@ public class OrderLineItemProvisioningStatus
     private Iterable<QuantityProvisioningStatus> quantityProvisioningInformation;
 
     /**
-     * The status of the order line item number.
+     * The aggregated state of an order line item.
      */
     private String status;
 
@@ -40,7 +40,7 @@ public class OrderLineItemProvisioningStatus
     }
 
     /**
-     * Set the order line item number.
+     * Sets the order line item number.
      * 
      * @param value The order line item number.
      */
@@ -60,7 +60,7 @@ public class OrderLineItemProvisioningStatus
     }
 
     /**
-     * Set the quantity provisioning information.
+     * Sets the quantity provisioning information.
      * 
      * @param value The quantity provisioning information.
      */
@@ -70,7 +70,7 @@ public class OrderLineItemProvisioningStatus
     }
 
     /**
-     * Gets aggregated state of an order line item.
+     * Gets the aggregated state of an order line item.
      * 
      * @return The aggregated state of an order line item.
      */
@@ -80,7 +80,7 @@ public class OrderLineItemProvisioningStatus
     }
 
     /**
-     * Set the aggregated state of an order line item..
+     * Sets the aggregated state of an order line item.
      * 
      * @param value The aggregated state of an order line item.
      */

--- a/src/main/java/com/microsoft/store/partnercenter/models/products/Availability.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/products/Availability.java
@@ -16,6 +16,81 @@ public class Availability
     extends ResourceBaseWithLinks<StandardResourceLinks>
 {
     /**
+     * A flag indicating whether the availability is purchasable or not.
+     */
+    private boolean isPurchasable;
+
+    /**
+     * A flag indicating whether the availability is renewable or not.
+     */
+    private boolean isRenewable;
+
+    /**
+     * The terms if applicable to this availability.
+     */
+    private Iterable<AvailabilityTerm> terms;
+
+    /**
+     * Gets a flag indicating whether the availability is purchasable or not.
+     * 
+     * @return A flag indicating whether the availability is purchasable or not.
+     */
+    public boolean getIsPurchasable()
+    {
+        return isPurchasable;
+    }
+
+    /**
+     * Sets a flag indicating whether the availability is purchasable or not.
+     * 
+     * @param value A flag indicating whether the availability is purchasable or not.
+     */
+    public void setIsPurchasable(boolean value)
+    {
+        isPurchasable = value;   
+    }
+
+    /**
+     * Gets a flag indicating whether the availability is renewable or not.
+     * 
+     * @return A flag indicating whether the availability is renewable or not.
+     */
+    public boolean getIsRenewable()
+    {
+        return isRenewable;
+    }
+
+    /**
+     * Sets a flag indicating whether the availability is renewable or not.
+     * 
+     * @param value A flag indicating whether the availability is renewable or not.
+     */
+    public void setIsRenewable(boolean value)
+    {
+        isRenewable = value;   
+    }
+
+    /**
+     * Gets the terms if applicable to this availability.
+     * 
+     * @return The terms if applicable to this availability.
+     */
+    public Iterable<AvailabilityTerm> getTerms()
+    {
+        return terms;
+    }
+
+    /**
+     * Sets the terms if applicable to this availability.
+     * 
+     * @param value The terms if applicable to this availability.
+     */
+    public void setTerms(Iterable<AvailabilityTerm> value)
+    {
+        terms = value;   
+    }
+
+    /**
      * Gets or sets the unique availability id.
      */
     private String __Id;

--- a/src/main/java/com/microsoft/store/partnercenter/models/products/AvailabilityTerm.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/products/AvailabilityTerm.java
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------
+// <copyright file="AvailabilityTerm.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.products;
+
+/**
+ *Represents the terms for an availability.
+ */
+public class AvailabilityTerm
+{
+    /**
+     * The description for the term.
+     */
+    private String description;
+
+    /**
+     * The ISO standard representation of this term's duration.
+     */
+    private String duration;
+
+    /**
+     * Gets the description for the term.
+     * 
+     * @return The description for the term.
+     */
+    public String getDescription()
+    {
+        return description;
+    }
+
+    /**
+     * Sets the description for the term.
+     * 
+     * @param value The description for the term.
+     */
+    public void setDescription(String value)
+    {
+        description = value;
+    }
+
+    /**
+     * Gets the ISO standard representation of this term's duration.
+     * 
+     * @return The ISO standard representation of this term's duration.
+     */
+    public String getDuration()
+    {
+        return duration;
+    }
+
+    /**
+     * Sets the ISO standard representation of this term's duration.
+     * 
+     * @param value The ISO standard representation of this term's duration. 
+     */
+    public void setDuration(String value)
+    {
+        duration = value;
+    }
+}

--- a/src/main/java/com/microsoft/store/partnercenter/models/products/Product.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/products/Product.java
@@ -16,6 +16,56 @@ public class Product
     extends ResourceBaseWithLinks<StandardResourceLinks>
 {
     /**
+     * A flag indicating whether this is a Microsoft product or not.
+     */
+    private boolean isMicrosoftProduct;
+
+    /**
+     * The name of the publisher.
+     */
+    private String publisherName;
+
+    /**
+     * Gets a flag indicating whether this is a Microsoft product or not.
+     * 
+     * @return A flag indicating whether this is a Microsoft product or not.
+     */
+    public boolean getIsMicrosoftProduct()
+    {
+        return isMicrosoftProduct;
+    }
+
+    /**
+     * Sets a flag indicating whether this is a Microsoft product or not.
+     * 
+     * @param value A flag indicating whether this is a Microsoft product or not.
+     */
+    public void setIsMicrosoftProduct(boolean value)
+    {
+        isMicrosoftProduct = value;
+    }
+
+    /**
+     * Gets the name of the publisher.
+     * 
+     * @return The name of the publisher.
+     */
+    public String getPublisherName()
+    {
+        return publisherName;
+    }
+
+    /**
+     * Sets the name of the publisher.
+     * 
+     * @param value The name of the publisher.
+     */
+    public void setPublisherName(String value)
+    {
+        publisherName = value;
+    }
+
+    /**
      * Gets or sets the id.
      */
     private String __Id;

--- a/src/main/java/com/microsoft/store/partnercenter/models/validationcodes/ValidationCode.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/validationcodes/ValidationCode.java
@@ -1,0 +1,163 @@
+// -----------------------------------------------------------------------
+// <copyright file="ValidationCode.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.validationcodes;
+
+/**
+ * Represents validation codes. Used to create Government Community Cloud (GCC) accounts.
+ */
+public class ValidationCode
+{
+    /**
+     * The etag value for the object.
+     */
+    private String etag; 
+
+    /**
+     * The maximum number of customer creates for this code.
+     */
+    private int maxCreates;
+
+    /**
+     * The name of the organization.
+     */
+    private String organizationName;
+
+    /**
+     * The identifier for the partner.
+     */
+    private String partnerId; 
+
+    /** 
+     * The remaining number of customer creates for this code.
+     */
+    private int remainingCreates;
+
+    /**
+     * The identifier for the validation.
+     */
+    private String validationId;
+
+    /**
+     * Gets the ETag value for the object.
+     * 
+     * @return The ETag value for the object.
+     */
+    public String getETag()
+    {
+        return etag;
+    }
+
+    /**
+     * Sets the ETag value for the object.
+     * 
+     * @param value The ETag value for the object.
+     */
+    public void setETag(String value)
+    {
+        etag = value;
+    }
+
+    /**
+     * Gets the maximum number of customer creates for this code.
+     * 
+     * @return The maximum number of customer creates for this code.
+     */
+    public int getMaxCreates()
+    {
+        return maxCreates;
+    }
+
+    /**
+     * Sets the maximum number of customer creates for this code.
+     * 
+     * @param value The maximum number of customer creates for this code.
+     */
+    public void setMaxCreates(int value)
+    {
+        maxCreates = value;
+    }
+
+    /**
+     * Gets the name of the organization.
+     * 
+     * @return The name of the organization.
+     */
+    public String getOrganizationName()
+    {
+        return organizationName;
+    }
+
+    /**
+     * Sets the name of the organization.
+     * 
+     * @param value The name of the organization.
+     */
+    public void setOrganizationName(String value)
+    {
+        organizationName = value;
+    }
+
+    /**
+     * Gets the identifier for the partner.
+     * 
+     * @return The identifier for the partner.
+     */
+    public String getPartnerId()
+    {
+        return partnerId;
+    }
+
+    /**
+     * Sets the identifier for the partner.
+     * 
+     * @param value The identifier for the partner.
+     */
+    public void setPartnerId(String value)
+    {
+        partnerId = value;
+    }
+
+    /**
+     * Gets the remaining number of customer creates for this code.
+     * 
+     * @return The remaining number of customer creates for this code.
+     */
+    public int getRemainingCreates()
+    {
+        return remainingCreates;
+    }
+
+    /**
+     * Sets the remaining number of customer creates for this code.
+     * 
+     * @param value The remaining number of customer creates for this code.
+     */
+    public void setRemainingCreates(int value)
+    {
+        remainingCreates = value;
+    }
+
+    /**
+     * Gets the identifier for the validation.
+     * 
+     * @return The identifier for the validation.
+     */
+    public String getValidationId()
+    {
+        return validationId;
+    }
+
+    /**
+     * Sets the identifier for the validation.
+     * 
+     * @param value The identifier for the validation.
+     */
+    public void setValidationId(String value)
+    {
+        validationId = value;
+    }
+}

--- a/src/main/java/com/microsoft/store/partnercenter/orders/IOrder.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/IOrder.java
@@ -19,24 +19,24 @@ public interface IOrder
     extends IPartnerComponent<Tuple<String, String>>, IEntityGetOperations<Order>, IEntityPatchOperations<Order>
 {
     /**
+     * Gets the line item collection operations.
+     * 
+     * @return The line item collection operations.
+     */
+    IOrderLineItemCollection getOrderLineItems();
+
+    /**
+     * Gets the order provisioning status operations.
+     * 
+     * @return The order provisioning status operations.
+     */
+    IOrderProvisioningStatus getProvisioningStatus();
+
+    /**
      * Gets the order information.
      * 
      * @param includePrice A flag indicating whether to include pricing details in the order information or not.
      * @return The order information including pricing details (based on access permissions) when requested.
      */
     Order get(Boolean includePrice);
-
-    /**
-     * Gets line item collection operations.
-     * 
-     * @return The line item collection operations.
-     */    
-    IOrderLineItemCollection getOrderLineItems();
-
-    /**
-     * Gets the order provisioning status operations.
-     * 
-     * @return The order provisioning status operation.
-     */
-    IOrderProvisioningStatus getProvisioningStatus();
 }

--- a/src/main/java/com/microsoft/store/partnercenter/orders/IOrderCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/IOrderCollection.java
@@ -33,7 +33,7 @@ public interface IOrderCollection
      * Gets a collection of orders.
      * 
      * @param includePrice A flag indicating whether to include pricing details in the order information or not.
-     * @return The collection of orders.
+     * @return The collection of orders including pricing details (based on access permissions) when requested.
      */
     ResourceCollection<Order> get(Boolean includePrice);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/orders/IOrderLineItemCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/IOrderLineItemCollection.java
@@ -11,7 +11,7 @@ import com.microsoft.store.partnercenter.genericoperations.IEntitySelector;
 import com.microsoft.store.partnercenter.models.utils.Tuple;
 
 /**
- * Represents the available order line item operations.
+ * Represents the available order line item collection operations.
  */
 public interface IOrderLineItemCollection
     extends IPartnerComponent<Tuple<String, String>>, IEntitySelector<Integer, IOrderLineItem>

--- a/src/main/java/com/microsoft/store/partnercenter/orders/IOrderProvisioningStatus.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/IOrderProvisioningStatus.java
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="IOrderProvisioningStatus.java" company="Microsoft">
+// <copyright file="IOrderLineItemCollection.java" company="Microsoft">
 //      Copyright (c) Microsoft Corporation. All rights reserved.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -13,9 +13,9 @@ import com.microsoft.store.partnercenter.models.orders.OrderLineItemProvisioning
 import com.microsoft.store.partnercenter.models.utils.Tuple;
 
 /**
- * Represents the available order provisioning status operations.
+ * Represents the operations that apply Order provisioning status.
  */
 public interface IOrderProvisioningStatus
-    extends IPartnerComponent<Tuple<String, String>>, IEntireEntityCollectionRetrievalOperations<OrderLineItemProvisioningStatus, ResourceCollection<OrderLineItemProvisioningStatus>>
+    extends  IPartnerComponent<Tuple<String, String>>, IEntireEntityCollectionRetrievalOperations<OrderLineItemProvisioningStatus, ResourceCollection<OrderLineItemProvisioningStatus>>
 {
 }

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderCollectionOperations.java
@@ -35,15 +35,30 @@ public class OrderCollectionOperations
 	 */
 	public OrderCollectionOperations( IPartner rootPartnerOperations, String customerId )
 	{
-		super( rootPartnerOperations, customerId );
-		if ( StringHelper.isNullOrWhiteSpace( customerId ) )
+		super(rootPartnerOperations, customerId);
+		
+		if (StringHelper.isNullOrWhiteSpace(customerId))
 		{
-			throw new IllegalArgumentException( "customerId must be set." );
+			throw new IllegalArgumentException("customerId must be set");
 		}
 	}
 
+    /**
+     * Gets the order collection behavior given a billing cycle type.
+     * 
+     * @param billingCycleType The billing cycle type.
+     * @return The order collection by billing cycle type.
+     */
+	public IOrderCollectionByBillingCycleType byBillingCycleType(BillingCycleType billingCycleType)
+	{
+		return new OrderCollectionByBillingCycleTypeOperations(
+			this.getPartner(), 
+			this.getContext(), 
+			billingCycleType);
+	}
+
 	/**
-	 * Gets a specific order behavior.
+	 * Get the order operations for the specified order.
 	 * 
 	 * @param orderId The order identifier.
 	 * @return The order operations.
@@ -52,18 +67,6 @@ public class OrderCollectionOperations
 	public IOrder byId( String orderId )
 	{
 		return new OrderOperations( this.getPartner(), this.getContext(), orderId );
-	}
-
-	/**
-     * Gets the order collection behavior given a billing cycle type.
-     * 
-     * @param billingCycleType The billing cycle type.
-     * @return The order collection by billing cycle type.
-     */
-	@Override
-	public IOrderCollectionByBillingCycleType byBillingCycleType(BillingCycleType billingCycleType)
-	{
-		return new OrderCollectionByBillingCycleTypeOperations(this.getPartner(), this.getContext(), billingCycleType);
 	}
 
 	/**
@@ -89,33 +92,36 @@ public class OrderCollectionOperations
 			newOrder);
 	}
 
-    /**
-     * Gets a collection of orders.
-     * 
-     * @return The collection of orders.
-     */
+	/**
+	 * Retrieves all the orders the customer made.
+	 * 
+	 * @return All the customer orders.
+	 */
 	@Override
 	public ResourceCollection<Order> get()
 	{
-		return this.get(false);
+		return get(false);
 	}
 
-    /**
+	/**
      * Gets a collection of orders.
      * 
      * @param includePrice A flag indicating whether to include pricing details in the order information or not.
-     * @return The collection of orders.
+     * @return The collection of orders including pricing details (based on access permissions) when requested.
      */
-	@Override
 	public ResourceCollection<Order> get(Boolean includePrice)
 	{
 		Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
 
-		parameters.add(
-			new KeyValuePair<String, String>(
+		parameters.add
+		(
+			new KeyValuePair<String, String>
+			(
 				PartnerService.getInstance().getConfiguration().getApis().get("GetOrders").getParameters().get("IncludePrice"),
-				String.valueOf(includePrice)));   
-
+				String.valueOf(includePrice)
+			) 
+		);
+		
 		return this.getPartner().getServiceClient().get(
 			this.getPartner(),
 			new TypeReference<ResourceCollection<Order>>(){}, 

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemActivationLinkOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemActivationLinkOperations.java
@@ -18,32 +18,37 @@ import com.microsoft.store.partnercenter.models.utils.TripletTuple;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
- * Order operations implementation class.
+ * Order collection operations implementation class.
  */
-public class OrderLineItemActivationLinkOperations extends BasePartnerComponent<TripletTuple<String, String, Integer>>
-        implements IOrderLineItemActivationLink {
+public class OrderLineItemActivationLinkOperations 
+    extends BasePartnerComponent<TripletTuple<String, String, Integer>>
+    implements IOrderLineItemActivationLink         
+{
     /**
-     * Initializes a new instance of the OrderOperations class.
+     * Initializes a new instance of the OrderLineItemActivationLinkOperations class.
      * 
      * @param rootPartnerOperations The root partner operations instance.
-     * @param customerId            The customer identifier.
-     * @param orderId               The order identifier.
+     * @param customerId The identifier for the customer.
+     * @param orderId The identifier for the order.
+     * @param lineItemNumber The order line item number.
      */
-    public OrderLineItemActivationLinkOperations(IPartner rootPartnerOperations, String customerId, String orderId,
-            Integer lineItemNumber) {
+    public OrderLineItemActivationLinkOperations(IPartner rootPartnerOperations, String customerId, String orderId, int lineItemNumber) 
+    {
         super(rootPartnerOperations, new TripletTuple<String, String, Integer>(customerId, orderId, lineItemNumber));
 
-        if (StringHelper.isNullOrWhiteSpace(customerId)) {
-            throw new IllegalArgumentException("customerId must be set.");
+        if (StringHelper.isNullOrWhiteSpace(customerId)) 
+        {
+            throw new IllegalArgumentException("customerId must be set");
         }
 
-        if (StringHelper.isNullOrWhiteSpace(orderId)) {
-            throw new IllegalArgumentException("orderId must be set.");
+        if (StringHelper.isNullOrWhiteSpace(orderId)) 
+        {
+            throw new IllegalArgumentException("orderId must be set");
         }
     }
 
     /**
-     * Retrieves the order line item activation link collection.
+     * Gets the order line item activation link collection.
      * 
      * @return The order line item activation link collection.
      */

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemCollectionOperations.java
@@ -12,11 +12,11 @@ import com.microsoft.store.partnercenter.models.utils.Tuple;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
- * Order operations implementation class.
+ * Implements the order collection operations.
  */
-public class OrderLineItemCollectionOperations
-    extends BasePartnerComponent<Tuple<String, String>>
-    implements IOrderLineItemCollection
+public class OrderLineItemCollectionOperations 
+    extends BasePartnerComponent<Tuple<String, String>> 
+    implements IOrderLineItemCollection 
 {
     /**
      * Initializes a new instance of the OrderLineItemCollectionOperations class.
@@ -25,33 +25,31 @@ public class OrderLineItemCollectionOperations
      * @param customerId The customer identifier.
      * @param orderId The order identifier.
      */
-    public OrderLineItemCollectionOperations( IPartner rootPartnerOperations, String customerId, String orderId )
-    {
-        super( rootPartnerOperations, new Tuple<String, String>( customerId, orderId ) );
+    public OrderLineItemCollectionOperations(IPartner rootPartnerOperations, String customerId, String orderId) {
+        super(rootPartnerOperations, new Tuple<String, String>(customerId, orderId));
 
-        if ( StringHelper.isNullOrWhiteSpace( customerId ) )
+        if (StringHelper.isNullOrWhiteSpace(customerId)) 
         {
-            throw new IllegalArgumentException( "customerId must be set." );
+            throw new IllegalArgumentException("customerId must be set.");
         }
 
-        if ( StringHelper.isNullOrWhiteSpace( orderId ) )
+        if (StringHelper.isNullOrWhiteSpace(orderId)) 
         {
-            throw new IllegalArgumentException( "orderId must be set." );
+            throw new IllegalArgumentException("orderId must be set.");
         }
     }
 
     /**
-     * Gets the order line item operations.
+     * Gets the available order line item operations.
      * 
-     * @param id The order line item number.
-     * @return The order line item operations.
+     * @return The available order line item operations.
      */
     @Override
     public IOrderLineItem byId(Integer id) 
     {
         return new OrderLineItemOperations(
             this.getPartner(), 
-            this.getContext().getItem1(), 
+            this.getContext().getItem1(),
             this.getContext().getItem2(), 
             id);
     }

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderLineItemOperations.java
@@ -12,43 +12,46 @@ import com.microsoft.store.partnercenter.models.utils.TripletTuple;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
- * Implements the available order line item operations.
+ * Implements the order collection operations.
  */
-public class OrderLineItemOperations
+public class OrderLineItemOperations 
     extends BasePartnerComponent<TripletTuple<String, String, Integer>>
-    implements IOrderLineItem
+    implements IOrderLineItem 
 {
     /**
-     * Initializes a new instance of the OrderLineItemCollectionOperations class.
+     * Initializes a new instance of the OrderLineItemOperations class.
      * 
      * @param rootPartnerOperations The root partner operations instance.
      * @param customerId The customer identifier.
      * @param orderId The order identifier.
+     * @param lineItemNumber The line item number.
      */
-    public OrderLineItemOperations(IPartner rootPartnerOperations, String customerId, String orderId, int lineItemNumber)
+    public OrderLineItemOperations(IPartner rootPartnerOperations, String customerId, String orderId, int lineItemNumber) 
     {
-        super( rootPartnerOperations, new TripletTuple<String, String, Integer>(customerId, orderId, lineItemNumber));
+        super(rootPartnerOperations, new TripletTuple<String, String, Integer>(customerId, orderId, lineItemNumber));
 
-        if (StringHelper.isNullOrWhiteSpace(customerId))
+        if (StringHelper.isNullOrWhiteSpace(customerId)) 
         {
             throw new IllegalArgumentException("customerId must be set.");
         }
 
-        if (StringHelper.isNullOrWhiteSpace(orderId))
+        if (StringHelper.isNullOrWhiteSpace(orderId)) 
         {
             throw new IllegalArgumentException("orderId must be set.");
         }
     }
 
-    /**
+    /** 
      * Gets the available customer order line item activation link operations.
+     * 
+     * @return The available customer order line item activation link operations.
      */
     public IOrderLineItemActivationLink getActivationLink()
     {
         return new OrderLineItemActivationLinkOperations(
-            this.getPartner(),
+            this.getPartner(), 
             this.getContext().getItem1(), 
             this.getContext().getItem2(), 
             this.getContext().getItem3());
-    }
+    } 
 }

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderOperations.java
@@ -49,7 +49,7 @@ public class OrderOperations
     }
 
     /**
-     * Retrieves the customer order.
+     * Gets the order information.
      * 
      * @return The customer order.
      */
@@ -70,11 +70,15 @@ public class OrderOperations
     {
         Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
 
-		parameters.add(
-			new KeyValuePair<String, String>(
+		parameters.add
+		(
+			new KeyValuePair<String, String>
+			(
 				PartnerService.getInstance().getConfiguration().getApis().get("GetOrder").getParameters().get("IncludePrice"),
-                String.valueOf(includePrice)));   
-                
+				String.valueOf(includePrice)
+			) 
+        );
+        
         return this.getPartner().getServiceClient().get(
             this.getPartner(),
             new TypeReference<Order>(){}, 
@@ -89,22 +93,28 @@ public class OrderOperations
      * Gets line item collection operations.
      * 
      * @return The line item collection operations.
-     */    
+     */
     @Override
     public IOrderLineItemCollection getOrderLineItems() 
     {
-        return new OrderLineItemCollectionOperations(this.getPartner(), this.getContext().getItem1(), this.getContext().getItem2());
+        return new OrderLineItemCollectionOperations(
+            this.getPartner(),
+            this.getContext().getItem1(), 
+            this.getContext().getItem2());
     }
 
     /**
      * Gets the order provisioning status operations.
      * 
-     * @return The order provisioning status operation.
+     * @return The order provisioning status operations.
      */
     @Override
     public IOrderProvisioningStatus getProvisioningStatus() 
     {
-        return new OrderProvisioningStatusOperations(this.getPartner(), this.getContext().getItem1(), this.getContext().getItem2());
+        return new OrderProvisioningStatusOperations(
+            this.getPartner(), 
+            this.getContext().getItem1(), 
+            this.getContext().getItem2());
     }
 
     /**
@@ -118,7 +128,7 @@ public class OrderOperations
     {
         if ( order == null )
         {
-            throw new IllegalArgumentException( "Order cannot be null" );
+            throw new IllegalArgumentException( "Order can't be null" );
         }
 
         return this.getPartner().getServiceClient().patch(

--- a/src/main/java/com/microsoft/store/partnercenter/orders/OrderProvisioningStatusOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/orders/OrderProvisioningStatusOperations.java
@@ -20,24 +20,29 @@ import com.microsoft.store.partnercenter.utils.StringHelper;
 /**
  * Implements operations that apply to order provisioning status.
  */
-public class OrderProvisioningStatusOperations extends BasePartnerComponent<Tuple<String, String>>
-        implements IOrderProvisioningStatus {
+public class OrderProvisioningStatusOperations
+    extends BasePartnerComponent<Tuple<String, String>>
+    implements IOrderProvisioningStatus
+{
     /**
      * Initializes a new instance of the OrderProvisioningStatusOperations class.
      * 
      * @param rootPartnerOperations The root partner operations instance.
-     * @param customerId            The customer identifier.
-     * @param orderId               The order identifier.
+     * @param customerId The customer identifier.
+     * @param orderId The order identifier.
      */
-    public OrderProvisioningStatusOperations(IPartner rootPartnerOperations, String customerId, String orderId) {
+    public OrderProvisioningStatusOperations(IPartner rootPartnerOperations, String customerId, String orderId)
+    {
         super(rootPartnerOperations, new Tuple<String, String>(customerId, orderId));
 
-        if (StringHelper.isNullOrWhiteSpace(customerId)) {
-            throw new IllegalArgumentException("customerId must be set.");
+        if (StringHelper.isNullOrWhiteSpace(customerId))
+        {
+            throw new IllegalArgumentException( "customerId must be set");
         }
 
-        if (StringHelper.isNullOrWhiteSpace(orderId)) {
-            throw new IllegalArgumentException("orderId must be set.");
+        if (StringHelper.isNullOrWhiteSpace( orderId ) )
+        {
+            throw new IllegalArgumentException( "orderId must be set");
         }
     }
 
@@ -47,7 +52,7 @@ public class OrderProvisioningStatusOperations extends BasePartnerComponent<Tupl
      * @return The provisioning status for the order.
      */
     @Override
-    public ResourceCollection<OrderLineItemProvisioningStatus> get() 
+    public ResourceCollection<OrderLineItemProvisioningStatus> get()
     {
         return this.getPartner().getServiceClient().get(
             this.getPartner(),
@@ -56,5 +61,5 @@ public class OrderProvisioningStatusOperations extends BasePartnerComponent<Tupl
                 PartnerService.getInstance().getConfiguration().getApis().get("GetOrderProvisioningStatus").getPath(),
                 this.getContext().getItem1(), 
                 this.getContext().getItem2()));
-    }
+	}
 }

--- a/src/main/java/com/microsoft/store/partnercenter/qualification/CustomerQualificationOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/qualification/CustomerQualificationOperations.java
@@ -7,12 +7,16 @@
 package com.microsoft.store.partnercenter.qualification;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponentString;
 import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
 import com.microsoft.store.partnercenter.models.customers.CustomerQualification;
+import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
+import com.microsoft.store.partnercenter.models.validationcodes.ValidationCode;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
@@ -28,11 +32,11 @@ public class CustomerQualificationOperations
 	 * @param rootPartnerOperations The root partner operations instance.
 	 * @param customerId The customer identifier.
 	 */
-	public CustomerQualificationOperations( IPartner rootPartnerOperations, String customerId )
+	public CustomerQualificationOperations(IPartner rootPartnerOperations, String customerId)
 	{
-		super( rootPartnerOperations, customerId );
+		super(rootPartnerOperations, customerId);
 
-		if ( StringHelper.isNullOrEmpty( customerId ) )
+		if (StringHelper.isNullOrEmpty(customerId))
 		{
 			throw new IllegalArgumentException("customerId must be set.");
 		}
@@ -61,11 +65,11 @@ public class CustomerQualificationOperations
 	 * @return The updated customer qualification.
 	 */
 	@Override
-	public CustomerQualification update( CustomerQualification customerQualification )
+	public CustomerQualification update(CustomerQualification customerQualification)
 	{
 		if ( customerQualification == null )
 		{
-			throw new IllegalArgumentException( "customerQualification null" );
+			throw new IllegalArgumentException("customerQualification must be set");
 		}
 		
 		return this.getPartner().getServiceClient().put(
@@ -75,5 +79,44 @@ public class CustomerQualificationOperations
 				PartnerService.getInstance().getConfiguration().getApis().get("UpdateCustomerQualification").getPath(),
 				this.getContext()),
 			customerQualification);
+	}
+
+	/**
+     * Updates the customer qualification. Used for GovernmentCommunityCloud with validation code after successful registration through Microsoft.
+     * 
+     * @param customerQualification The customer qualification value.
+     * @param governmentCommunityCloudValidationCode Validation code necessary to complete only Government Community Cloud customer creation.
+     * @return The updated customer qualification.
+     */
+	public CustomerQualification update(CustomerQualification customerQualification, ValidationCode governmentCommunityCloudValidationCode)
+	{
+		if (customerQualification == null)
+		{
+			throw new IllegalArgumentException("customerQualification must be set");
+		}
+		
+		if(governmentCommunityCloudValidationCode == null)
+		{
+			throw new IllegalArgumentException("governmentCommunityCloudValidationCode must be set");
+		}
+		
+		Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
+
+		parameters.add
+		(
+			new KeyValuePair<String, String>
+			(
+				PartnerService.getInstance().getConfiguration().getApis().get("UpdateCustomerQualification").getParameters().get("GovernmentCommunityCloudValidationCode"),
+				governmentCommunityCloudValidationCode.getValidationId()
+			) 
+		);
+
+		return this.getPartner().getServiceClient().put(
+			this.getPartner(),
+			new TypeReference<CustomerQualification>(){}, 
+			MessageFormat.format( 
+				PartnerService.getInstance().getConfiguration().getApis().get("UpdateCustomerQualification").getPath(),
+				this.getContext()),
+			customerQualification);	
 	}
 }

--- a/src/main/java/com/microsoft/store/partnercenter/qualification/ICustomerQualification.java
+++ b/src/main/java/com/microsoft/store/partnercenter/qualification/ICustomerQualification.java
@@ -10,6 +10,7 @@ import com.microsoft.store.partnercenter.IPartnerComponentString;
 import com.microsoft.store.partnercenter.genericoperations.IEntityGetOperations;
 import com.microsoft.store.partnercenter.genericoperations.IEntityUpdateOperations;
 import com.microsoft.store.partnercenter.models.customers.CustomerQualification;
+import com.microsoft.store.partnercenter.models.validationcodes.ValidationCode;
 
 public interface ICustomerQualification
 		extends IPartnerComponentString, IEntityGetOperations<CustomerQualification>, IEntityUpdateOperations<CustomerQualification>
@@ -27,6 +28,14 @@ public interface ICustomerQualification
      * @param customerQualification Customer Qualification.
      * @return The updated customer qualification.
      */
-    CustomerQualification update( CustomerQualification customerQualification );
+    CustomerQualification update(CustomerQualification customerQualification);
 
+    /**
+     * Updates the customer qualification. Used for GovernmentCommunityCloud with validation code after successful registration through Microsoft.
+     * 
+     * @param customerQualification The customer qualification value.
+     * @param governmentCommunityCloudValidationCode Validation code necessary to complete only Government Community Cloud customer creation.
+     * @return The updated customer qualification.
+     */
+    CustomerQualification update(CustomerQualification customerQualification, ValidationCode governmentCommunityCloudValidationCode);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/utils/InvoiceLineItemDeserializer.java
+++ b/src/main/java/com/microsoft/store/partnercenter/utils/InvoiceLineItemDeserializer.java
@@ -29,11 +29,13 @@ public class InvoiceLineItemDeserializer
 {
     private static final long serialVersionUID = 2L;
 
-    public InvoiceLineItemDeserializer() { 
+    public InvoiceLineItemDeserializer() 
+    { 
         this(null); 
     } 
  
-    public InvoiceLineItemDeserializer(Class<?> vc) { 
+    public InvoiceLineItemDeserializer(Class<?> vc) 
+    { 
         super(vc); 
     }
 

--- a/src/main/java/com/microsoft/store/partnercenter/validations/IValidationOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/validations/IValidationOperations.java
@@ -6,8 +6,11 @@
 
 package com.microsoft.store.partnercenter.validations;
 
+import java.util.List;
+
 import com.microsoft.store.partnercenter.IPartnerComponentString;
 import com.microsoft.store.partnercenter.models.Address;
+import com.microsoft.store.partnercenter.models.validationcodes.ValidationCode;
 
 /**
  * Represents the behavior of a validation operations.
@@ -16,10 +19,17 @@ public interface IValidationOperations
     extends IPartnerComponentString
 {
     /**
+     * Gets validation code which is used for Government Community Cloud customers qualification.
+     * 
+     * @return List of validation codes.
+     */
+    List<ValidationCode> getValidationCodes();
+
+    /**
      * Checks if the address is valid or not.
      * 
      * @param address The address to be validated.
-     * @return True if the address is valid, false otherwise.
+     * @return true if the address is valid, false otherwise.
      */
     Boolean isAddressValid(Address address);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/validations/ValidationOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/validations/ValidationOperations.java
@@ -6,11 +6,14 @@
 
 package com.microsoft.store.partnercenter.validations;
 
+import java.util.List;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponentString;
 import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
 import com.microsoft.store.partnercenter.models.Address;
+import com.microsoft.store.partnercenter.models.validationcodes.ValidationCode;
 
 /**
  * The validations collection operations implementation.
@@ -24,9 +27,22 @@ public class ValidationOperations
      * 
      * @param rootPartnerOperations The root partner operations instance.
      */
-    public ValidationOperations( IPartner rootPartnerOperations )
+    public ValidationOperations(IPartner rootPartnerOperations)
     {
-        super( rootPartnerOperations );
+        super(rootPartnerOperations);
+    }
+
+    /**
+     * Gets validation code which is used for Government Community Cloud customers qualification.
+     * 
+     * @return List of validation codes.
+     */
+    public List<ValidationCode> getValidationCodes()
+    {
+		return this.getPartner().getServiceClient().get(
+			this.getPartner(), 
+			new TypeReference<List<ValidationCode>>(){},
+			PartnerService.getInstance().getConfiguration().getApis().get("GetValidationCodes").getPath());
     }
 
     /**
@@ -39,7 +55,7 @@ public class ValidationOperations
     {
         if ( address == null )
         {
-            throw new IllegalArgumentException( "The address is a required parameter." );
+            throw new IllegalArgumentException("The address is a required parameter.");
         }
 
         return this.getPartner().getServiceClient().post(

--- a/src/main/resources/PartnerService.json
+++ b/src/main/resources/PartnerService.json
@@ -5,7 +5,7 @@
   "DefaultAuthenticationTokenExpiryBufferInSeconds": "30",
   "DefaultLocale": "en-US",
   "PartnerCenterClient": "Partner Center Java SDK",
-  "SdkVersion" : "1.11.0",
+  "SdkVersion": "1.12.0",
   "Apis": {
     "PartnerLicensesDeploymentInsights": {
       "Path": "analytics/licenses/deployment"
@@ -28,11 +28,11 @@
         "Size": "size"
       }
     },
-    "CreateCustomerAgreement": {
-      "Path": "customers/{0}/agreements"
-    },
     "GetAgreementsDetails": {
       "Path": "agreements"
+    },
+    "CreateCustomerAgreement": {
+      "Path": "customers/{0}/agreements"
     },
     "GetCustomerAgreements": {
       "Path": "customers/{0}/agreements"
@@ -276,8 +276,8 @@
     "GetCustomerSubscribedSkus": {
       "Path": "customers/{0}/subscribedskus",
       "Parameters": {
-        "customerId": "customer_id",
-        "licenseGroupIds": "licenseGroupIds"
+        "CustomerId": "customer_id",
+        "LicenseGroupIds": "licenseGroupIds"
       }
     },
     "GetCustomerDirectoryRoles": {
@@ -364,11 +364,20 @@
     "GetActivationLinksByLineItemNumber": {
       "Path": "customers/{0}/orders/{1}/lineitems/{2}/activationlinks"
     },
+    "GetSubscriptionActivationLink": {
+      "Path": "{0}/subscriptions/{1}/activationlinks"
+    },
     "GetCustomerQualification": {
       "Path": "customers/{0}/qualification"
     },
     "UpdateCustomerQualification": {
-      "Path": "customers/{0}/qualification"
+      "Path": "customers/{0}/qualification",
+      "Parameters": {
+        "GovernmentCommunityCloudValidationCode": "code"
+      }
+    },
+    "GetValidationCodes": {
+      "Path": "customers/all/validations"
     },
     "GetCustomerManagedServices": {
       "Path": "customers/{0}/managedservices"
@@ -517,6 +526,26 @@
     "GetInvoiceSummaries": {
       "Path": "invoices/summaries"
     },
+    "GetReconLineItems": {
+      "Path": "invoices/{0}/lineitems",
+      "Parameters": {
+        "Provider": "provider",
+        "InvoiceLineItemType": "invoiceLineItemType",
+        "CurrencyCode": "currencyCode",
+        "Period": "period",
+        "Size": "size",
+        "SeekOperation": "seekoperation"
+      },
+      "AdditionalHeaders": {
+        "ContinuationToken": "MS-ContinuationToken"
+      }
+    },
+    "GetEstimatesLinks": {
+      "Path": "invoices/estimates/links",
+      "Parameters": {
+        "CurrencyCode": "currencyCode"
+      }
+    },
     "GetCustomerBillingProfile": {
       "Path": "customers/{0}/profiles/billing"
     },
@@ -634,6 +663,9 @@
     "DeleteDevice": {
       "Path": "customers/{0}/deviceBatches/{1}/devices/{2}"
     },
+    "UpdateDevice": {
+      "Path": "customers/{0}/deviceBatches/{1}/devices/{2}"
+    },
     "GetBatchUploadStatus": {
       "Path": "customers/{0}/batchJobStatus/{1}"
     },
@@ -684,7 +716,11 @@
     "GetEntitlements": {
       "Path": "customers/{0}/entitlements",
       "Parameters": {
-        "EntitlementType": "entitlementType"
+        "EntitlementType": "entitlementType",
+        "ShowExpiry": "showExpiry"
+      },
+      "AdditionalHeaders": {
+        "Version": "version"
       }
     }
   }

--- a/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingProviderTest.java
+++ b/src/test/java/com/microsoft/store/partnercenter/models/invoices/BillingProviderTest.java
@@ -6,14 +6,15 @@
 
 package com.microsoft.store.partnercenter.models.invoices;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.store.partnercenter.TestJsonConverter;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.store.partnercenter.TestJsonConverter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class BillingProviderTest
 {


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made

* Devices
  * Addressed issue with the device update operation
* Entitlements
  * Added the ability to obtain the expiration date for the entitlement (if applicable)
  * Added the AlternateId property to the reference order object
  * Added the following properties to the Entitlement model
    * FulfillmentState
    * ExpiryDate
* Invoices
  * Added the following properties to the OneTimeInvoiceLineItem model
    * AlternateId
    * ChargeEndDate
    * ChargeStartDate
    * PublisherId
    * PublisherName
    * SubscriptionDescription
    * SubscriptionId
    * TermAndBillingCycle
    * UnitType
  * Removed Azure Data Market billing provider type and models because this is no longer supported
* Orders
  * Added the ability to get the activation link for an order line item
  * Added the ability to include pricing details in the order information returned when requesting a list of customer orders
* Products
  * Added the following properties to the Availability model
    * IsPurchasable
    * IsRenewable
    * Terms
  * Added the following properties to the Product model
    * IsMicrosoftProduct
    * PublisherName
  * Removed the SKU download operations
* Qualifications
  * Added the ability to update the customer qualification used for Government Community Cloud.
* Validations
  * Added the ability to request validation codes used to create Government Community Cloud customers