### PR TITLE
Fix wrong detection of the first parameter

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/network/PartnerServiceClient.java
+++ b/src/main/java/com/microsoft/store/partnercenter/network/PartnerServiceClient.java
@@ -470,9 +470,10 @@ public class PartnerServiceClient
 					address.append("?");
 				}
 
+				boolean firstParameter = true;
 				for (KeyValuePair<String, String> queryParameter : parameters)
 				{
-					if (address.length() > 1) {
+					if (!firstParameter) {
 						address.append("&");
 					}
 
@@ -481,6 +482,7 @@ public class PartnerServiceClient
 							"{0}={1}", 
 							queryParameter.getKey(), 
 							queryParameter.getValue()));
+					firstParameter = false;
 				} 
 			}
 		} 


### PR DESCRIPTION
Add boolean flag for checks the first parameter. The condition with address.length() is wrong, is always greater than 1 because it's the length of the string which already contains the root URL.