### PR TITLE
Add parameter agreement type into get agreement metadata request

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementDetailsCollectionByAgreementTypeOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementDetailsCollectionByAgreementTypeOperations.java
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.store.partnercenter.BasePartnerComponent;
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
+import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Agreement details operations by agreement type implementation class.
+ */
+public class AgreementDetailsCollectionByAgreementTypeOperations
+    extends BasePartnerComponent<AgreementType>
+    implements IAgreementDetailsCollectionByAgreementType
+{
+    /**
+     * Initializes a new instance of the AgreementDetailsCollectionByAgreementTypeOperations class.
+     *
+     * @param rootPartnerOperations The root partner operations instance.
+     * @param agreementType The identifier of the agreement type.
+     */
+    public AgreementDetailsCollectionByAgreementTypeOperations(IPartner rootPartnerOperations, AgreementType agreementType)
+    {
+        super(rootPartnerOperations, agreementType);
+
+        if (agreementType == null)
+        {
+            throw new IllegalArgumentException("agreementType must be set");
+        }
+    }
+
+    /**
+     * Retrieves all current agreement metadata for specified agreement type.
+     *
+     * @return A list of agreement details for specified agreement type.
+     */
+    @Override
+    public ResourceCollection<AgreementMetaData> get()
+    {
+        Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
+
+        parameters.add
+        (
+            new KeyValuePair<String, String>
+            (
+                PartnerService.getInstance().getConfiguration().getApis().get("GetAgreementsDetails").getParameters().get("AgreementType"),
+                this.getContext().toString()
+            )
+        );
+
+        return this.getPartner().getServiceClient().get(
+                this.getPartner(),
+                new TypeReference<ResourceCollection<AgreementMetaData>>(){},
+                PartnerService.getInstance().getConfiguration().getApis().get("GetAgreementsDetails").getPath(),
+                parameters);
+    }
+}

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementDetailsCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementDetailsCollectionOperations.java
@@ -9,6 +9,7 @@ import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
 
 /**
  * Agreement details collection operations implementation class.
@@ -39,5 +40,17 @@ public class AgreementDetailsCollectionOperations
             this.getPartner(),
             new TypeReference<ResourceCollection<AgreementMetaData>>(){}, 
             PartnerService.getInstance().getConfiguration().getApis().get("GetAgreementsDetails").getPath());
+    }
+
+    /**
+     * Retrieves the operations tied with a specified agreement type.
+     *
+     * @param agreementType The agreement type filter.
+     * @return The available operations for agreement details.
+     */
+    @Override
+    public IAgreementDetailsCollectionByAgreementType byAgreementType(AgreementType agreementType)
+    {
+        return new AgreementDetailsCollectionByAgreementTypeOperations(this.getPartner(), agreementType);
     }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/CustomerAgreementCollectionByAgreementTypeOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/CustomerAgreementCollectionByAgreementTypeOperations.java
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.store.partnercenter.BasePartnerComponent;
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
+import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
+import com.microsoft.store.partnercenter.models.utils.Tuple;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Customer agreements operations by agreement type implementation class.
+ */
+public class CustomerAgreementCollectionByAgreementTypeOperations
+        extends BasePartnerComponent<Tuple<String, AgreementType>>
+        implements ICustomerAgreementCollectionByAgreementType
+{
+    /**
+     * Initializes a new instance of the CustomerAgreementCollectionByAgreementTypeOperations class.
+     *
+     * @param rootPartnerOperations The root partner operations instance.
+     * @param customerId The customer identifier.
+     * @param agreementType The identifier of the agreement type.
+     */
+    public CustomerAgreementCollectionByAgreementTypeOperations(IPartner rootPartnerOperations, String customerId, AgreementType agreementType)
+    {
+        super(rootPartnerOperations, new Tuple<String, AgreementType>(customerId, agreementType));
+
+        if (agreementType == null)
+        {
+            throw new IllegalArgumentException("agreementType must be set");
+        }
+    }
+
+    /**
+     * Gets the list of agreements between a partner and customer for specified agreement type.
+     *
+     * @return The list of the customer's agreements for specified agreement type.
+     */
+    @Override
+    public ResourceCollection<Agreement> get()
+    {
+        Collection<KeyValuePair<String, String>> parameters = new ArrayList<KeyValuePair<String, String>>();
+
+        parameters.add
+        (
+            new KeyValuePair<String, String>
+            (
+                    PartnerService.getInstance().getConfiguration().getApis().get("GetAgreementsDetails").getParameters().get("AgreementType"),
+                    this.getContext().getItem2().toString()
+            )
+        );
+
+        return this.getPartner().getServiceClient().get(
+                this.getPartner(),
+                new TypeReference<ResourceCollection<Agreement>>(){},
+                MessageFormat.format(
+                        PartnerService.getInstance().getConfiguration().getApis().get("GetCustomerAgreements").getPath(),
+                        this.getContext().getItem1()),
+                parameters);
+    }
+}

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/CustomerAgreementCollectionOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/CustomerAgreementCollectionOperations.java
@@ -11,6 +11,7 @@ import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
 import com.microsoft.store.partnercenter.utils.StringHelper;
 
 /**
@@ -37,16 +38,15 @@ public class CustomerAgreementCollectionOperations
     }
 
     /**
-     * Adds accepted agreement.
+     * Creates an agreement between the partner and customer.
      *
-     * @param newAgreement Agreement to add.
-     *
-     * @return Agreement entity.
+     * @param newEntity The agreement to be created.
+     * @return The newly created agreement.
      */
     @Override
-    public Agreement create(Agreement newAgreement)
+    public Agreement create(Agreement newEntity)
     {
-        if (newAgreement == null)
+        if (newEntity == null)
         {
             throw new IllegalArgumentException("Agreement can't be null.");
         }
@@ -57,13 +57,13 @@ public class CustomerAgreementCollectionOperations
             MessageFormat.format(
                 PartnerService.getInstance().getConfiguration().getApis().get("CreateCustomerAgreement").getPath(),
                 this.getContext()),
-            newAgreement);
+            newEntity);
     }
 
     /**
-     * Retrieves all agreements.
+     * Gets the list of agreements between a partner and customer.
      *
-     * @return A collection of all agreements.
+     * @return The list of the customer's agreements.
      */
     @Override
     public ResourceCollection<Agreement> get()
@@ -74,5 +74,17 @@ public class CustomerAgreementCollectionOperations
             MessageFormat.format(
                 PartnerService.getInstance().getConfiguration().getApis().get("GetCustomerAgreements").getPath(),
                 this.getContext()));
+    }
+
+    /**
+     * Retrieves the operations tied with a specified agreement type.
+     *
+     * @param agreementType The agreement type filter.
+     * @return The available operations for agreement details.
+     */
+    @Override
+    public ICustomerAgreementCollectionByAgreementType byAgreementType(final AgreementType agreementType)
+    {
+        return new CustomerAgreementCollectionByAgreementTypeOperations(this.getPartner(), this.getContext(), agreementType);
     }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementDetailsCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementDetailsCollection.java
@@ -17,7 +17,7 @@ public interface IAgreementDetailsCollection
         IEntireEntityCollectionRetrievalOperations<AgreementMetaData, ResourceCollection<AgreementMetaData>>
 {
     /**
-     * Retrieves all current agreement metadata.
+     * Gets the agreement details.
      *
      * @return The current agreement metadata.
      */

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementDetailsCollectionByAgreementType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementDetailsCollectionByAgreementType.java
@@ -3,31 +3,23 @@
 
 package com.microsoft.store.partnercenter.agreements;
 
-import com.microsoft.store.partnercenter.IPartnerComponentString;
+import com.microsoft.store.partnercenter.IPartnerComponent;
 import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
 import com.microsoft.store.partnercenter.models.agreements.AgreementType;
 
 /**
- * Encapsulates the operations on the agreement metadata collection.
+ * Encapsulates the operations on the agreement metadata by agreement type collection.
  */
-public interface IAgreementDetailsCollection
-        extends IPartnerComponentString,
+public interface IAgreementDetailsCollectionByAgreementType
+        extends IPartnerComponent<AgreementType>,
         IEntireEntityCollectionRetrievalOperations<AgreementMetaData, ResourceCollection<AgreementMetaData>>
 {
     /**
-     * Retrieves all current agreement metadata.
+     * Retrieves all current agreement metadata for specified agreement type.
      *
-     * @return The current agreement metadata.
+     * @return A list of agreement details for specified agreement type.
      */
     ResourceCollection<AgreementMetaData> get();
-
-    /**
-     * Retrieves the operations tied with a specified agreement type.
-     *
-     * @param agreementType The agreement type filter.
-     * @return The available operations for agreement details.
-     */
-    IAgreementDetailsCollectionByAgreementType byAgreementType(AgreementType agreementType);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/ICustomerAgreementCollection.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/ICustomerAgreementCollection.java
@@ -7,6 +7,7 @@ import com.microsoft.store.partnercenter.IPartnerComponentString;
 import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
 import com.microsoft.store.partnercenter.models.ResourceCollection;
 import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
 
 /**
  * Encapsulates the operations on the Agreement collection.
@@ -16,18 +17,25 @@ public interface ICustomerAgreementCollection
         IEntireEntityCollectionRetrievalOperations<Agreement, ResourceCollection<Agreement>>
 {
     /**
-     * Adds accepted agreement.
+     * Creates an agreement between the partner and customer.
      *
-     * @param newEntity Agreement to add.
-     *
-     * @return Agreement entity.
+     * @param newEntity The agreement to be created.
+     * @return The newly created agreement.
      */
     Agreement create(Agreement newEntity);
 
     /**
-     * Retrieves all agreements.
+     * Gets the list of agreements between a partner and customer.
      *
-     * @return The agreements.
+     * @return The list of the customer's agreements.
      */
     ResourceCollection<Agreement> get();
+
+    /**
+     * Retrieves the operations tied with a specified agreement type.
+     *
+     * @param agreementType The agreement type filter.
+     * @return The available operations for agreement details.
+     */
+    ICustomerAgreementCollectionByAgreementType byAgreementType(AgreementType agreementType);
 }

--- a/src/main/java/com/microsoft/store/partnercenter/agreements/ICustomerAgreementCollectionByAgreementType.java
+++ b/src/main/java/com/microsoft/store/partnercenter/agreements/ICustomerAgreementCollectionByAgreementType.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for full license information.
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.microsoft.store.partnercenter.IPartnerComponent;
+import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
+import com.microsoft.store.partnercenter.models.utils.Tuple;
+
+/**
+ * Encapsulates the operations on the Agreement collection by agreement type.
+ */
+public interface ICustomerAgreementCollectionByAgreementType
+        extends IPartnerComponent<Tuple<String, AgreementType>>,
+        IEntireEntityCollectionRetrievalOperations<Agreement, ResourceCollection<Agreement>>
+{
+    /**
+     * Retrieves all agreements for specified agreement type.
+     *
+     * @return The agreements for specified agreement type.
+     */
+    ResourceCollection<Agreement> get();
+}

--- a/src/main/resources/PartnerService.json
+++ b/src/main/resources/PartnerService.json
@@ -38,7 +38,10 @@
       "Path": "customers/{0}/agreements"
     },
     "GetCustomerAgreements": {
-      "Path": "customers/{0}/agreements"
+      "Path": "customers/{0}/agreements",
+      "Parameters": {
+        "AgreementType": "agreementType"
+      }
     },
     "CreateCustomerApplicationConsent": {
       "Path": "customers/{0}/applicationconsents"

--- a/src/main/resources/PartnerService.json
+++ b/src/main/resources/PartnerService.json
@@ -29,7 +29,10 @@
       }
     },
     "GetAgreementsDetails": {
-      "Path": "agreements"
+      "Path": "agreements",
+      "Parameters": {
+        "AgreementType": "agreementType"
+      }
     },
     "CreateCustomerAgreement": {
       "Path": "customers/{0}/agreements"


### PR DESCRIPTION
# Add parameter agreement type into get agreement metadata request

According to the documentation [1](https://docs.microsoft.com/en-us/partner-center/develop/get-customer-agreement-metadata) and [2](https://docs.microsoft.com/en-us/partner-center/develop/get-confirmation-of-customer-agreement) added optional parameter `agreementType` into _Get agreement metadata_ and _Get confirmation of customer acceptance_ requests.

Getting a list of all available types of agreements:
`partnerOperations.getAgreementDetails().get();`

Getting a list of specified type of agreements:
`partnerOperations.getAgreementDetails().byAgreementType(agreementType).get();`

Getting a list of all agreements between a partner and customer:
`partnerOperations.getCustomers().byId(customerId).getAgreements().get()`

Getting a list of specified type agreements between a partner and customer:
`partnerOperations.getCustomers().byId(customerId).getAgreements().byAgreementType(agreementType).get()`
