### PR TITLE
Updating the com.fasterxml.jackson dependencies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,14 @@
 
 # Change Log
 
+## 1.14.1
+
+* Dependency
+  * Updated the *com.fasterxml.jackson.core.jackson-annotations* dependency from version 2.9.9 to 2.9.10
+  * Updated the *com.fasterxml.jackson.core.jackson-core* dependency from version 2.9.9 to 2.9.10
+  * Updated the *com.fasterxml.jackson.core.jackson-databind* dependency from version 2.9.9 to 2.9.10
+  * Updated the *com.fasterxml.jackson.datatype.jackson-datatype-joda* dependency from version 2.9.9 to 2.9.10
+
 ## 1.14.0
 
 * Agreements
@@ -34,7 +42,7 @@
 * Customer users
   * Addressed issue [#39](https://github.com/microsoft/Partner-Center-Java/issues/39) preventing sorting from working as expected when querying customer users
 * Dependencies
-  * Updated the *com.microsoft.rest.client-runtime* from version 1.6.5 to 1.6.12
+  * Updated the *com.microsoft.rest.client-runtime* dependency from version 1.6.5 to 1.6.12
 * Invoices
   * Both functions named By in the invoice operations class have been renamed to by
 * JDK

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Jar dependency binary information for maven and gradle can be found here at [mav
 <dependency>
     <groupId>com.microsoft.store</groupId>
     <artifactId>partnercenter</artifactId>
-    <version>1.14.0</version>
+    <version>1.14.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.store</groupId>
   <artifactId>partnercenter</artifactId>
-  <version>1.14.0</version>
+  <version>1.14.1</version>
   <packaging>jar</packaging>
   <name>Partner Center Java SDK</name>
   <description>SDK for accessing Microsoft Partner Center API.</description>
@@ -76,22 +76,22 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.2</version>
+      <version>[2.9.10,)</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.9</version>
+      <version>[2.9.10,)</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.9</version>
+      <version>[2.9.10,)</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.9.9</version>
+      <version>[2.9.10,)</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.rest</groupId>

--- a/src/main/resources/PartnerService.json
+++ b/src/main/resources/PartnerService.json
@@ -5,7 +5,7 @@
   "DefaultAuthenticationTokenExpiryBufferInSeconds": "120",
   "DefaultLocale": "en-US",
   "PartnerCenterClient": "Partner Center Java SDK",
-  "SdkVersion": "1.14.0",
+  "SdkVersion": "1.14.1",
   "Apis": {
     "PartnerLicensesDeploymentInsights": {
       "Path": "analytics/licenses/deployment"


### PR DESCRIPTION
# Description

Through this pull request the following changes are being made 

* Dependency
  * Updated the *com.fasterxml.jackson.core.jackson-annotations* dependency from version 2.9.9 to 2.9.10
  * Updated the *com.fasterxml.jackson.core.jackson-core* dependency from version 2.9.9 to 2.9.10
  * Updated the *com.fasterxml.jackson.core.jackson-databind* dependency from version 2.9.9 to 2.9.10
  * Updated the *com.fasterxml.jackson.datatype.jackson-datatype-joda* dependency from version 2.9.9 to 2.9.10

## Related issue

This change is related to the following 

* [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540)
* [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335)
