### PR TITLE
Remove redundant call toString which can lead to NullPointerException

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/exception/PartnerResponseParseException.java
+++ b/src/main/java/com/microsoft/store/partnercenter/exception/PartnerResponseParseException.java
@@ -96,7 +96,7 @@ public class PartnerResponseParseException
     {
         return MessageFormat.format(
             "PartnerApiParsingException: Response: {0}, Base Description: {1}",
-            this.getResponse().toString(), 
+            this.getResponse(),
             super.toString());
     }
 }


### PR DESCRIPTION
# Description

Remove redundant call toString which can lead to NullPointerException.
