### PR TITLE
Fix broken API calls related to purchasing Azure Reserved Instances

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/extensions/products/ProductExtensionsByCountryOperations.java
+++ b/src/main/java/com/microsoft/store/partnercenter/extensions/products/ProductExtensionsByCountryOperations.java
@@ -19,7 +19,7 @@ import com.microsoft.store.partnercenter.models.utils.KeyValuePair;
 /**
  * Product extensions operations implementation by country.
  */
-public class ProductExtensionsByCountryOperations 
+public class ProductExtensionsByCountryOperations
     extends BasePartnerComponentString implements IProductExtensionsByCountry 
 {
     /**
@@ -53,8 +53,9 @@ public class ProductExtensionsByCountryOperations
 
         return this.getPartner().getServiceClient().post(
             this.getPartner(),
-            new TypeReference<List<InventoryItem>>(){}, 
+            new TypeReference<List<InventoryItem>>(){},
             PartnerService.getInstance().getConfiguration().getApis().get("CheckInventory").getPath(),
+            checkRequest,
             parameters);
     }
 }

--- a/src/main/java/com/microsoft/store/partnercenter/models/utils/QuintupleTuple.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/utils/QuintupleTuple.java
@@ -21,6 +21,7 @@ public class QuintupleTuple<T1, T2, T3, T4, T5>
         this.item2 = item2;
         this.item3 = item3;
         this.item4 = item4;
+        this.item5 = item5;
     }
 
     public T1 getItem1()

--- a/src/main/resources/PartnerService.json
+++ b/src/main/resources/PartnerService.json
@@ -86,7 +86,7 @@
       }
     },
     "CheckInventory": {
-      "Path": "extensions/product/checkinventory",
+      "Path": "extensions/product/checkInventory",
       "Parameters": {
         "Country": "country"
       }


### PR DESCRIPTION
# Description
1. "checkInventory" call was broken since "checkRequest" parameter was not used in the method.
2. Requests with 5-items contexts were broken since the 5th parameter was not used in QuintupleTuple constructor.