### PR TITLE
Issue #127 Fix fail deserialization additionalInfo

### DIFF
--- a/src/main/java/com/microsoft/store/partnercenter/models/invoices/DailyRatedUsageLineItem.java
+++ b/src/main/java/com/microsoft/store/partnercenter/models/invoices/DailyRatedUsageLineItem.java
@@ -20,8 +20,7 @@ public class DailyRatedUsageLineItem
     /**
      * The service-specific metadata. For example, an image type for a virtual machine.
      */
-    @JsonDeserialize(using = NestedResourceDeserializer.class)
-    private Map<String, Object> additionalInfo;
+    private String additionalInfo;
 
     /**
      * The availability identifier associated with the invoice line item.
@@ -279,7 +278,7 @@ public class DailyRatedUsageLineItem
      * 
      * @return The service-specific metadata. For example, an image type for a virtual machine.
      */
-    public Map<String, Object> getAdditionalInfo()
+    public String getAdditionalInfo()
     {
         return additionalInfo;
     }
@@ -289,7 +288,7 @@ public class DailyRatedUsageLineItem
      * 
      * @param value The service-specific metadata. For example, an image type for a virtual machine.
     */
-    public void setAdditionalInfo(Map<String, Object> value)
+    public void setAdditionalInfo(String value)
     {
         additionalInfo = value;
     }


### PR DESCRIPTION
# Description

A value of field `additionalInfo` is actually not a map every time. Some times it is a string.

## Related issue

Fixes #127 